### PR TITLE
feat(plugin,server): Handle instance renames in ChangeTracker

### DIFF
--- a/plugin/src/ChangeTracker.luau
+++ b/plugin/src/ChangeTracker.luau
@@ -384,7 +384,86 @@ local function trackInstanceChanges(instance: Instance)
 
     -- Track name changes (renames)
     local nameConnection = instance:GetPropertyChangedSignal("Name"):Connect(function()
-        -- TODO: Handle renames (need old path)
+        -- Primary echo prevention: suppress ALL changes during inbound sync
+        if isSyncingFromServer then
+            return
+        end
+
+        -- Get the OLD path (stored before rename)
+        local oldPath = instancePaths[instance]
+        if not oldPath then
+            -- Instance wasn't tracked, nothing to rename
+            return
+        end
+
+        -- Calculate the NEW path by walking up the parent tree
+        local parts = {}
+        local current = instance
+        while current and current ~= game do
+            table.insert(parts, 1, current.Name)
+            current = current.Parent
+        end
+
+        if #parts == 0 then
+            return
+        end
+
+        -- Check if new path is in a tracked service
+        local serviceName = parts[1]
+        local isTracked = false
+        for _, tracked in trackedServices do
+            if tracked == serviceName then
+                isTracked = true
+                break
+            end
+        end
+
+        if not isTracked then
+            return
+        end
+
+        local newPath = table.concat(parts, "/")
+
+        -- Skip if path didn't actually change (shouldn't happen, but be safe)
+        if oldPath == newPath then
+            return
+        end
+
+        -- Update the stored path immediately
+        instancePaths[instance] = newPath
+
+        -- Path-based deduplication: skip if recently applied from server (50ms window)
+        if recentlyApplied[oldPath] and (tick() - recentlyApplied[oldPath]) < APPLY_DEBOUNCE then
+            return
+        end
+        if recentlyApplied[newPath] and (tick() - recentlyApplied[newPath]) < APPLY_DEBOUNCE then
+            return
+        end
+
+        -- Secondary echo prevention: grace period for file watcher paths
+        if shouldIgnoreChange(oldPath) or shouldIgnoreChange(newPath) then
+            return
+        end
+
+        -- Log the rename
+        print("[RbxSync Debug] Queueing rename: " .. oldPath .. " -> " .. newPath)
+
+        -- Queue rename operation (use newPath as key since that's the current identity)
+        pendingChanges[newPath] = {
+            path = newPath,
+            className = instance.ClassName,
+            changeType = "rename",
+            data = {
+                oldPath = oldPath,
+                newPath = newPath,
+            },
+            timestamp = tick(),
+        }
+
+        -- Remove any pending changes for the old path (they're now stale)
+        if pendingChanges[oldPath] then
+            pendingChanges[oldPath] = nil
+        end
     end)
 
     table.insert(connections, nameConnection)


### PR DESCRIPTION
## Summary
- Implements rename handling in the ChangeTracker plugin module
- When an instance is renamed in Studio, the old and new paths are tracked
- Server handles rename operations by moving files/directories accordingly

## Changes
- **plugin/src/ChangeTracker.luau**: Added rename detection in `GetPropertyChangedSignal("Name")` handler that captures old/new paths and queues a "rename" operation
- **rbxsync-server/src/lib.rs**: Added "rename" case handler that moves files and directories to their new paths

## Test Plan
- [ ] Rename a Script in Studio and verify the file is renamed on disk
- [ ] Rename a Folder with children and verify the directory is renamed
- [ ] Verify echo prevention works (rename from server doesn't echo back)

Fixes RBXSYNC-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)