### PR TITLE
Fix: Reuse existing console terminal (RBXSYNC-18)

### DIFF
--- a/rbxsync-vscode/src/extension.ts
+++ b/rbxsync-vscode/src/extension.ts
@@ -8,7 +8,7 @@ import { connectCommand, disconnectCommand } from './commands/connect';
 import { extractCommand } from './commands/extract';
 import { syncCommand } from './commands/sync';
 import { runPlayTest, disposeTestChannel } from './commands/test';
-import { openConsole, closeConsole, toggleE2EMode, initE2EMode, disposeConsole, isE2EMode } from './commands/console';
+import { openConsole, closeConsole, toggleE2EMode, initE2EMode, initConsole, disposeConsole, isE2EMode } from './commands/console';
 import { initTrashSystem, recoverDeletedFolder } from './commands/trash';
 import {
   LanguageClient,
@@ -33,6 +33,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // Initialize E2E mode from saved state
   initE2EMode(context);
+
+  // Initialize console terminal tracking (handles terminal close events)
+  initConsole(context);
 
   // Set project directory for multi-workspace support
   const workspaceFolders = vscode.workspace.workspaceFolders;


### PR DESCRIPTION
## Summary
- Fix for multiple terminal windows being spawned in VS Code when opening console
- Console terminal is now reused if it exists and is still active
- Added terminal close listener to properly clean up reference when user closes terminal manually

## Changes Made
- **rbxsync-vscode/src/commands/console.ts**: 
  - Modified `openConsole()` to check `exitStatus` before creating new terminal
  - Added `initConsole()` function to register terminal close listener
- **rbxsync-vscode/src/extension.ts**: 
  - Import and call `initConsole()` during extension activation

## Test plan
- [ ] Open console multiple times - should reuse same terminal
- [ ] Close console manually and reopen - should create fresh terminal
- [ ] Extension should compile without errors

Fixes RBXSYNC-18

---
Generated with [Claude Code](https://claude.ai/code)