### PR TITLE
Fix: Prevent multiple terminal windows in VS Code (RBXSYNC-18)

### DIFF
--- a/rbxsync-vscode/src/commands/connect.ts
+++ b/rbxsync-vscode/src/commands/connect.ts
@@ -4,16 +4,38 @@ import { RbxSyncClient } from '../server/client';
 import { StatusBarManager } from '../views/statusBar';
 
 let serverTerminal: vscode.Terminal | null = null;
+let terminalCloseListener: vscode.Disposable | null = null;
+
+export function initServerTerminal(): vscode.Disposable {
+  if (terminalCloseListener) {
+    terminalCloseListener.dispose();
+  }
+  terminalCloseListener = vscode.window.onDidCloseTerminal((terminal) => {
+    if (terminal === serverTerminal) {
+      serverTerminal = null;
+    }
+  });
+  return terminalCloseListener;
+}
+
+export function disposeServerTerminal(): void {
+  if (serverTerminal) {
+    serverTerminal.dispose();
+    serverTerminal = null;
+  }
+  if (terminalCloseListener) {
+    terminalCloseListener.dispose();
+    terminalCloseListener = null;
+  }
+}
 
 export async function connectCommand(
   client: RbxSyncClient,
   statusBar: StatusBarManager
 ): Promise<void> {
-  // First check if server is already running
   let connected = await client.connect();
 
   if (connected) {
-    // Register workspace with server
     if (client.projectDir) {
       await client.registerWorkspace(client.projectDir);
     }
@@ -21,10 +43,8 @@ export async function connectCommand(
     return;
   }
 
-  // Server not running - start it
   vscode.window.showInformationMessage('Starting RbxSync server...');
 
-  // Create or reuse terminal
   if (!serverTerminal || serverTerminal.exitStatus !== undefined) {
     serverTerminal = vscode.window.createTerminal({
       name: 'RbxSync Server',
@@ -33,14 +53,12 @@ export async function connectCommand(
   }
 
   serverTerminal.sendText('rbxsync serve');
-  serverTerminal.show(true);  // Show but don't take focus
+  serverTerminal.show(true);
 
-  // Wait for server to start (poll up to 5 seconds)
   for (let i = 0; i < 10; i++) {
     await new Promise(resolve => setTimeout(resolve, 500));
     connected = await client.connect();
     if (connected) {
-      // Register workspace with server
       if (client.projectDir) {
         await client.registerWorkspace(client.projectDir);
       }
@@ -59,7 +77,6 @@ export async function disconnectCommand(
 ): Promise<void> {
   statusBar.stopPolling();
 
-  // Send shutdown request to server
   try {
     const config = vscode.workspace.getConfiguration('rbxsync');
     const port = config.get<number>('serverPort') || 44755;
@@ -75,7 +92,7 @@ export async function disconnectCommand(
         resolve();
       });
 
-      req.on('error', () => resolve());  // Server might close before responding
+      req.on('error', () => resolve());
       req.on('timeout', () => {
         req.destroy();
         resolve();
@@ -86,7 +103,7 @@ export async function disconnectCommand(
 
     vscode.window.showInformationMessage('RbxSync server stopped');
   } catch {
-    // Ignore errors - server might already be stopped
+    // Ignore errors
   }
 
   client['updateConnectionState']({ connected: false });


### PR DESCRIPTION
## Summary
- Fix multiple terminal windows being created in VS Code extension
- Add `onDidCloseTerminal` listeners to track when users close terminals manually
- Clear terminal references so new terminals are created instead of stale ones

## Changes
- `connect.ts`: Add `initServerTerminal()` and `disposeServerTerminal()` for server terminal tracking
- `console.ts`: Add `initConsoleTerminal()` for console terminal tracking
- `extension.ts`: Initialize terminal tracking during extension activation

## Root Cause
When users closed terminals by clicking the X button, the module-level terminal references (`serverTerminal`, `consoleTerminal`) weren't being cleared. This caused subsequent operations to fail to create new terminals properly, leading to duplicate terminal windows.

## Test plan
- [ ] Open VS Code with RbxSync extension
- [ ] Start the server (creates server terminal)
- [ ] Close the terminal manually (click X)
- [ ] Reconnect - should reuse/create single terminal, not multiple
- [ ] Open console terminal
- [ ] Close it manually
- [ ] Re-open - should create single terminal

Fixes RBXSYNC-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)