### PR TITLE
feat(discord): Add Discord feedback bot

### DIFF
--- a/rbxsync-discord/.env.example
+++ b/rbxsync-discord/.env.example
@@ -1,0 +1,7 @@
+# Discord Bot Token (required)
+# Get from https://discord.com/developers/applications
+DISCORD_TOKEN=your_bot_token_here
+
+# Optional: Channel ID to aggregate all reports
+# Leave empty to disable cross-posting
+REPORTS_CHANNEL_ID=

--- a/rbxsync-discord/.gitignore
+++ b/rbxsync-discord/.gitignore
@@ -1,0 +1,17 @@
+# Dependencies
+node_modules/
+
+# Environment
+.env
+.env.local
+
+# Reports (local storage)
+reports/
+
+# Logs
+*.log
+npm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db

--- a/rbxsync-discord/README.md
+++ b/rbxsync-discord/README.md
@@ -1,0 +1,209 @@
+# RbxSync Discord Feedback Bot
+
+A Discord bot for collecting user feedback and bug reports for RbxSync.
+
+## Features
+
+- **Slash Commands**: `/bug`, `/feedback`, `/feature` with modal forms
+- **Auto-Capture**: Monitors designated channels for reports
+- **Structured Reports**: Saves all reports as JSON files
+- **Rich Embeds**: Formatted responses with report IDs
+
+## Quick Start
+
+### 1. Create a Discord Bot
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click "New Application" and give it a name
+3. Go to "Bot" section and click "Add Bot"
+4. Under "Privileged Gateway Intents", enable:
+   - Message Content Intent
+5. Copy the bot token
+
+### 2. Invite Bot to Your Server
+
+1. Go to "OAuth2" > "URL Generator"
+2. Select scopes: `bot`, `applications.commands`
+3. Select bot permissions:
+   - Send Messages
+   - Send Messages in Threads
+   - Embed Links
+   - Read Message History
+   - Use Slash Commands
+4. Copy the generated URL and open it in your browser
+5. Select your server and authorize
+
+### 3. Configure Environment
+
+```bash
+cd rbxsync-discord
+cp .env.example .env
+```
+
+Edit `.env` with your bot token:
+
+```env
+DISCORD_TOKEN=your_bot_token_here
+REPORTS_CHANNEL_ID=optional_channel_id_for_aggregated_reports
+```
+
+### 4. Install and Run
+
+```bash
+npm install
+npm start
+```
+
+For development with auto-reload:
+
+```bash
+npm run dev
+```
+
+## Usage
+
+### Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/bug` | Opens a bug report form |
+| `/feedback` | Opens a feedback submission form |
+| `/feature` | Opens a feature request form |
+
+### Auto-Capture Channels
+
+The bot automatically captures messages in channels named:
+
+**Bug Reports:**
+- `bug-reports`
+- `bugs`
+- `rbxsync-bugs`
+
+**Feedback:**
+- `feedback`
+- `suggestions`
+- `rbxsync-feedback`
+
+### Report Storage
+
+Reports are saved as JSON files in the `reports/` directory:
+
+```
+reports/
+  bug-RPT-XXXXXX-YYYY.json
+  feedback-RPT-XXXXXX-YYYY.json
+  feature-RPT-XXXXXX-YYYY.json
+```
+
+Each report includes:
+- Unique report ID
+- Reporter info (Discord ID and tag)
+- Timestamp
+- Full report content
+- Status tracking
+
+## Report Format
+
+### Bug Report
+
+```json
+{
+  "id": "RPT-LXYZ1234-AB12",
+  "type": "bug",
+  "title": "Sync fails on large projects",
+  "description": "When syncing a project with 500+ scripts...",
+  "stepsToReproduce": "1. Open large project\n2. Run sync",
+  "version": "v1.1.2",
+  "reporter": {
+    "id": "123456789",
+    "tag": "user#1234"
+  },
+  "createdAt": "2026-01-16T12:00:00.000Z",
+  "status": "open"
+}
+```
+
+### Feedback Report
+
+```json
+{
+  "id": "RPT-LXYZ1234-AB12",
+  "type": "feedback",
+  "feedbackType": "UX",
+  "content": "The extraction process could show more progress...",
+  "reporter": {
+    "id": "123456789",
+    "tag": "user#1234"
+  },
+  "createdAt": "2026-01-16T12:00:00.000Z",
+  "status": "open"
+}
+```
+
+### Feature Request
+
+```json
+{
+  "id": "RPT-LXYZ1234-AB12",
+  "type": "feature",
+  "title": "Support for .rbxmx files",
+  "description": "Add ability to import/export .rbxmx format",
+  "useCase": "Would help with asset sharing between projects",
+  "reporter": {
+    "id": "123456789",
+    "tag": "user#1234"
+  },
+  "createdAt": "2026-01-16T12:00:00.000Z",
+  "status": "open"
+}
+```
+
+## Configuration Options
+
+| Environment Variable | Required | Description |
+|---------------------|----------|-------------|
+| `DISCORD_TOKEN` | Yes | Your Discord bot token |
+| `REPORTS_CHANNEL_ID` | No | Channel ID to aggregate all reports |
+
+## Development
+
+### Project Structure
+
+```
+rbxsync-discord/
+  src/
+    index.js      # Main bot code
+  reports/        # Saved reports (gitignored)
+  .env            # Environment config (gitignored)
+  .env.example    # Example environment config
+  package.json    # Dependencies
+  README.md       # This file
+```
+
+### Adding New Report Types
+
+1. Add a new slash command in the `commands` array
+2. Create a modal handler in `handleSlashCommand()`
+3. Add processing logic in `handleModalSubmit()`
+4. Create a report factory function (e.g., `createXxxReport()`)
+
+## Troubleshooting
+
+### Bot not responding to commands
+
+- Ensure the bot has proper permissions in your server
+- Check that slash commands are registered (wait a few minutes after first run)
+- Verify `DISCORD_TOKEN` is correct
+
+### Reports not saving
+
+- Check that the `reports/` directory is writable
+- Look for errors in the console output
+
+### Missing Message Content Intent
+
+If auto-capture doesn't work, enable "Message Content Intent" in the Discord Developer Portal under your bot's settings.
+
+## License
+
+MIT - Part of the RbxSync project

--- a/rbxsync-discord/package-lock.json
+++ b/rbxsync-discord/package-lock.json
@@ -1,0 +1,328 @@
+{
+  "name": "rbxsync-discord",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rbxsync-discord",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "discord.js": "^14.14.1",
+        "dotenv": "^16.3.1"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
+      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.37",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
+      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
+      "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
+      "license": "MIT"
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/rbxsync-discord/package.json
+++ b/rbxsync-discord/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "rbxsync-discord",
+  "version": "1.0.0",
+  "description": "Discord bot for collecting RbxSync user feedback and bug reports",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "node --watch src/index.js"
+  },
+  "keywords": [
+    "discord",
+    "rbxsync",
+    "feedback",
+    "bug-reports"
+  ],
+  "author": "RbxSync Team",
+  "license": "MIT",
+  "dependencies": {
+    "discord.js": "^14.14.1",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/rbxsync-discord/src/index.js
+++ b/rbxsync-discord/src/index.js
@@ -1,0 +1,428 @@
+require('dotenv').config();
+const { Client, GatewayIntentBits, EmbedBuilder, SlashCommandBuilder, REST, Routes, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+
+const client = new Client({
+    intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+    ],
+});
+
+const REPORTS_DIR = path.join(__dirname, '../reports');
+
+// Ensure reports directory exists
+if (!fs.existsSync(REPORTS_DIR)) {
+    fs.mkdirSync(REPORTS_DIR, { recursive: true });
+}
+
+// Slash commands definition
+const commands = [
+    new SlashCommandBuilder()
+        .setName('bug')
+        .setDescription('Report a bug in RbxSync'),
+    new SlashCommandBuilder()
+        .setName('feedback')
+        .setDescription('Submit feedback about RbxSync'),
+    new SlashCommandBuilder()
+        .setName('feature')
+        .setDescription('Request a new feature for RbxSync'),
+].map(command => command.toJSON());
+
+// Register slash commands when bot is ready
+client.once('ready', async () => {
+    console.log(`Logged in as ${client.user.tag}`);
+
+    const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
+
+    try {
+        console.log('Registering slash commands...');
+        await rest.put(
+            Routes.applicationCommands(client.user.id),
+            { body: commands },
+        );
+        console.log('Slash commands registered successfully');
+    } catch (error) {
+        console.error('Error registering commands:', error);
+    }
+});
+
+// Handle slash commands
+client.on('interactionCreate', async (interaction) => {
+    if (interaction.isChatInputCommand()) {
+        await handleSlashCommand(interaction);
+    } else if (interaction.isModalSubmit()) {
+        await handleModalSubmit(interaction);
+    } else if (interaction.isButton()) {
+        await handleButton(interaction);
+    }
+});
+
+async function handleSlashCommand(interaction) {
+    const { commandName } = interaction;
+
+    if (commandName === 'bug') {
+        const modal = new ModalBuilder()
+            .setCustomId('bug_report_modal')
+            .setTitle('Bug Report');
+
+        const titleInput = new TextInputBuilder()
+            .setCustomId('bug_title')
+            .setLabel('Bug Title')
+            .setPlaceholder('Brief description of the bug')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true)
+            .setMaxLength(100);
+
+        const descriptionInput = new TextInputBuilder()
+            .setCustomId('bug_description')
+            .setLabel('Description')
+            .setPlaceholder('What happened? What did you expect to happen?')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(true);
+
+        const stepsInput = new TextInputBuilder()
+            .setCustomId('bug_steps')
+            .setLabel('Steps to Reproduce')
+            .setPlaceholder('1. Do this\n2. Then this\n3. Bug occurs')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(false);
+
+        const versionInput = new TextInputBuilder()
+            .setCustomId('bug_version')
+            .setLabel('RbxSync Version')
+            .setPlaceholder('e.g., v1.1.2')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(false);
+
+        modal.addComponents(
+            new ActionRowBuilder().addComponents(titleInput),
+            new ActionRowBuilder().addComponents(descriptionInput),
+            new ActionRowBuilder().addComponents(stepsInput),
+            new ActionRowBuilder().addComponents(versionInput),
+        );
+
+        await interaction.showModal(modal);
+    } else if (commandName === 'feedback') {
+        const modal = new ModalBuilder()
+            .setCustomId('feedback_modal')
+            .setTitle('Submit Feedback');
+
+        const typeInput = new TextInputBuilder()
+            .setCustomId('feedback_type')
+            .setLabel('Feedback Type')
+            .setPlaceholder('General / UX / Performance / Documentation')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true);
+
+        const contentInput = new TextInputBuilder()
+            .setCustomId('feedback_content')
+            .setLabel('Your Feedback')
+            .setPlaceholder('Share your thoughts about RbxSync...')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(true);
+
+        modal.addComponents(
+            new ActionRowBuilder().addComponents(typeInput),
+            new ActionRowBuilder().addComponents(contentInput),
+        );
+
+        await interaction.showModal(modal);
+    } else if (commandName === 'feature') {
+        const modal = new ModalBuilder()
+            .setCustomId('feature_modal')
+            .setTitle('Feature Request');
+
+        const titleInput = new TextInputBuilder()
+            .setCustomId('feature_title')
+            .setLabel('Feature Title')
+            .setPlaceholder('Brief name for the feature')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true)
+            .setMaxLength(100);
+
+        const descriptionInput = new TextInputBuilder()
+            .setCustomId('feature_description')
+            .setLabel('Description')
+            .setPlaceholder('Describe the feature you want...')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(true);
+
+        const useCaseInput = new TextInputBuilder()
+            .setCustomId('feature_usecase')
+            .setLabel('Use Case')
+            .setPlaceholder('How would this feature help you?')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(false);
+
+        modal.addComponents(
+            new ActionRowBuilder().addComponents(titleInput),
+            new ActionRowBuilder().addComponents(descriptionInput),
+            new ActionRowBuilder().addComponents(useCaseInput),
+        );
+
+        await interaction.showModal(modal);
+    }
+}
+
+async function handleModalSubmit(interaction) {
+    const { customId } = interaction;
+
+    if (customId === 'bug_report_modal') {
+        const title = interaction.fields.getTextInputValue('bug_title');
+        const description = interaction.fields.getTextInputValue('bug_description');
+        const steps = interaction.fields.getTextInputValue('bug_steps') || 'Not provided';
+        const version = interaction.fields.getTextInputValue('bug_version') || 'Unknown';
+
+        const report = createBugReport(interaction.user, title, description, steps, version);
+        await saveReport('bug', report);
+
+        const embed = new EmbedBuilder()
+            .setColor(0xFF0000)
+            .setTitle('Bug Report Submitted')
+            .setDescription(`**${title}**`)
+            .addFields(
+                { name: 'Description', value: truncate(description, 1024) },
+                { name: 'Steps to Reproduce', value: truncate(steps, 1024) },
+                { name: 'Version', value: version, inline: true },
+                { name: 'Submitted by', value: interaction.user.tag, inline: true },
+                { name: 'Report ID', value: report.id, inline: true },
+            )
+            .setTimestamp();
+
+        await interaction.reply({ embeds: [embed] });
+
+        // Send to reports channel if configured
+        await sendToReportsChannel(interaction.guild, embed);
+    } else if (customId === 'feedback_modal') {
+        const type = interaction.fields.getTextInputValue('feedback_type');
+        const content = interaction.fields.getTextInputValue('feedback_content');
+
+        const report = createFeedbackReport(interaction.user, type, content);
+        await saveReport('feedback', report);
+
+        const embed = new EmbedBuilder()
+            .setColor(0x00FF00)
+            .setTitle('Feedback Submitted')
+            .addFields(
+                { name: 'Type', value: type, inline: true },
+                { name: 'Submitted by', value: interaction.user.tag, inline: true },
+                { name: 'Report ID', value: report.id, inline: true },
+                { name: 'Feedback', value: truncate(content, 1024) },
+            )
+            .setTimestamp();
+
+        await interaction.reply({ embeds: [embed] });
+        await sendToReportsChannel(interaction.guild, embed);
+    } else if (customId === 'feature_modal') {
+        const title = interaction.fields.getTextInputValue('feature_title');
+        const description = interaction.fields.getTextInputValue('feature_description');
+        const useCase = interaction.fields.getTextInputValue('feature_usecase') || 'Not provided';
+
+        const report = createFeatureRequest(interaction.user, title, description, useCase);
+        await saveReport('feature', report);
+
+        const embed = new EmbedBuilder()
+            .setColor(0x0099FF)
+            .setTitle('Feature Request Submitted')
+            .setDescription(`**${title}**`)
+            .addFields(
+                { name: 'Description', value: truncate(description, 1024) },
+                { name: 'Use Case', value: truncate(useCase, 1024) },
+                { name: 'Submitted by', value: interaction.user.tag, inline: true },
+                { name: 'Report ID', value: report.id, inline: true },
+            )
+            .setTimestamp();
+
+        await interaction.reply({ embeds: [embed] });
+        await sendToReportsChannel(interaction.guild, embed);
+    }
+}
+
+async function handleButton(interaction) {
+    // Reserved for future button interactions (e.g., marking reports as resolved)
+    await interaction.reply({ content: 'Button interaction received', ephemeral: true });
+}
+
+// Listen for messages in bug report channels
+client.on('messageCreate', async (message) => {
+    if (message.author.bot) return;
+
+    // Check if message is in a designated bug report channel
+    const bugChannelNames = ['bug-reports', 'bugs', 'rbxsync-bugs'];
+    const feedbackChannelNames = ['feedback', 'suggestions', 'rbxsync-feedback'];
+
+    const channelName = message.channel.name?.toLowerCase();
+
+    if (bugChannelNames.includes(channelName)) {
+        // Auto-format bug report from plain text
+        const report = createBugReportFromMessage(message);
+        await saveReport('bug', report);
+
+        const embed = new EmbedBuilder()
+            .setColor(0xFF0000)
+            .setTitle('Bug Report Logged')
+            .setDescription(truncate(message.content, 2048))
+            .addFields(
+                { name: 'Submitted by', value: message.author.tag, inline: true },
+                { name: 'Report ID', value: report.id, inline: true },
+            )
+            .setTimestamp();
+
+        await message.reply({ embeds: [embed] });
+    } else if (feedbackChannelNames.includes(channelName)) {
+        // Auto-format feedback from plain text
+        const report = createFeedbackFromMessage(message);
+        await saveReport('feedback', report);
+
+        const embed = new EmbedBuilder()
+            .setColor(0x00FF00)
+            .setTitle('Feedback Logged')
+            .setDescription(truncate(message.content, 2048))
+            .addFields(
+                { name: 'Submitted by', value: message.author.tag, inline: true },
+                { name: 'Report ID', value: report.id, inline: true },
+            )
+            .setTimestamp();
+
+        await message.reply({ embeds: [embed] });
+    }
+});
+
+// Helper functions
+function generateReportId() {
+    const timestamp = Date.now().toString(36);
+    const random = Math.random().toString(36).substring(2, 6);
+    return `RPT-${timestamp}-${random}`.toUpperCase();
+}
+
+function createBugReport(user, title, description, steps, version) {
+    return {
+        id: generateReportId(),
+        type: 'bug',
+        title,
+        description,
+        stepsToReproduce: steps,
+        version,
+        reporter: {
+            id: user.id,
+            tag: user.tag,
+        },
+        createdAt: new Date().toISOString(),
+        status: 'open',
+    };
+}
+
+function createBugReportFromMessage(message) {
+    const lines = message.content.split('\n');
+    const title = lines[0].substring(0, 100);
+    const description = lines.slice(1).join('\n') || lines[0];
+
+    return {
+        id: generateReportId(),
+        type: 'bug',
+        title,
+        description,
+        stepsToReproduce: 'Parsed from message',
+        version: 'Unknown',
+        reporter: {
+            id: message.author.id,
+            tag: message.author.tag,
+        },
+        messageId: message.id,
+        channelId: message.channel.id,
+        createdAt: new Date().toISOString(),
+        status: 'open',
+    };
+}
+
+function createFeedbackReport(user, type, content) {
+    return {
+        id: generateReportId(),
+        type: 'feedback',
+        feedbackType: type,
+        content,
+        reporter: {
+            id: user.id,
+            tag: user.tag,
+        },
+        createdAt: new Date().toISOString(),
+        status: 'open',
+    };
+}
+
+function createFeedbackFromMessage(message) {
+    return {
+        id: generateReportId(),
+        type: 'feedback',
+        feedbackType: 'General',
+        content: message.content,
+        reporter: {
+            id: message.author.id,
+            tag: message.author.tag,
+        },
+        messageId: message.id,
+        channelId: message.channel.id,
+        createdAt: new Date().toISOString(),
+        status: 'open',
+    };
+}
+
+function createFeatureRequest(user, title, description, useCase) {
+    return {
+        id: generateReportId(),
+        type: 'feature',
+        title,
+        description,
+        useCase,
+        reporter: {
+            id: user.id,
+            tag: user.tag,
+        },
+        createdAt: new Date().toISOString(),
+        status: 'open',
+    };
+}
+
+async function saveReport(type, report) {
+    const filename = `${type}-${report.id}.json`;
+    const filepath = path.join(REPORTS_DIR, filename);
+
+    try {
+        fs.writeFileSync(filepath, JSON.stringify(report, null, 2));
+        console.log(`Report saved: ${filename}`);
+    } catch (error) {
+        console.error('Error saving report:', error);
+    }
+}
+
+async function sendToReportsChannel(guild, embed) {
+    if (!guild || !process.env.REPORTS_CHANNEL_ID) return;
+
+    try {
+        const channel = await guild.channels.fetch(process.env.REPORTS_CHANNEL_ID);
+        if (channel) {
+            await channel.send({ embeds: [embed] });
+        }
+    } catch (error) {
+        console.error('Error sending to reports channel:', error);
+    }
+}
+
+function truncate(str, maxLength) {
+    if (!str) return 'N/A';
+    if (str.length <= maxLength) return str;
+    return str.substring(0, maxLength - 3) + '...';
+}
+
+// Login
+const token = process.env.DISCORD_TOKEN;
+if (!token) {
+    console.error('Error: DISCORD_TOKEN environment variable is not set');
+    console.error('Create a .env file with DISCORD_TOKEN=your_bot_token');
+    process.exit(1);
+}
+
+client.login(token);


### PR DESCRIPTION
## Summary

- Add `rbxsync-discord/` package with Discord.js bot for collecting user feedback and bug reports
- Slash commands: `/bug`, `/feedback`, `/feature` with modal forms for structured input
- Auto-capture: Monitors designated channels (bug-reports, feedback) and logs messages
- Saves structured JSON reports with unique IDs for tracking

## Changes

- `rbxsync-discord/src/index.js` - Main bot implementation
- `rbxsync-discord/package.json` - Dependencies (discord.js, dotenv)
- `rbxsync-discord/README.md` - Setup and usage instructions
- `rbxsync-discord/.env.example` - Environment template
- `rbxsync-discord/.gitignore` - Ignore node_modules, .env, reports

## Test plan

- [ ] Create Discord bot application and get token
- [ ] Run `npm install && npm start` in rbxsync-discord/
- [ ] Test `/bug` command opens modal and saves report
- [ ] Test `/feedback` command opens modal and saves report
- [ ] Test `/feature` command opens modal and saves report
- [ ] Test message auto-capture in bug-reports channel

Fixes RBXSYNC-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)