### PR TITLE
docs: Add LSP integration docs and improve extract explanation

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -46,12 +46,51 @@ You should see a green connection indicator.
 
 ## Extract Your Game
 
-If you have an existing game, click **Extract** in the plugin to convert it to files:
+**Extraction** converts your Roblox game into local files that can be version-controlled with Git.
+
+### What Gets Extracted
+
+| In Studio | Becomes |
+|-----------|---------|
+| Scripts | `.luau` files (ServerScript → `.server.luau`, LocalScript → `.client.luau`) |
+| Parts, Models, UI | `.rbxm` binary files |
+| Properties | `.rbxjson` metadata files |
+| Folders | Directories matching the hierarchy |
+| Terrain | `terrain/` voxel data |
+
+### How to Extract
 
 1. Open your existing game in Studio
-2. Connect to RbxSync
-3. Click **Extract**
-4. Your entire game is now version-controlled files
+2. Start the server: `rbxsync serve`
+3. Connect via the RbxSync plugin toolbar button
+4. Click **Extract** in the plugin panel
+
+Your game structure will appear in the `src/` folder:
+
+```
+src/
+├── Workspace/
+│   ├── Baseplate.rbxm
+│   └── SpawnLocation.rbxm
+├── ServerScriptService/
+│   └── GameManager.server.luau
+├── ReplicatedStorage/
+│   └── Modules/
+│       └── Utils.luau
+└── StarterPlayer/
+    └── StarterPlayerScripts/
+        └── ClientInit.client.luau
+```
+
+### When to Extract
+
+- **First time setup**: Convert an existing game to files
+- **After Studio-only changes**: Pull in changes made directly in Studio
+- **Team sync**: Get the latest from a teammate who worked in Studio
+
+::: tip
+Extraction also generates `project.json` for [Luau LSP](/vscode/luau-lsp), giving you intellisense in VS Code.
+:::
 
 ## Sync Changes
 

--- a/docs/vscode/commands.md
+++ b/docs/vscode/commands.md
@@ -59,3 +59,8 @@ Commit staged changes with a message.
 | `Cmd+Shift+E` | Extract Game |
 | `Cmd+Shift+S` | Sync Changes |
 | `Cmd+Shift+C` | Open Console |
+
+## Related
+
+- [Luau LSP Integration](/vscode/luau-lsp) - Intellisense and type checking setup
+- [E2E Testing](/vscode/e2e-testing) - Automated testing workflows

--- a/docs/vscode/luau-lsp.md
+++ b/docs/vscode/luau-lsp.md
@@ -1,0 +1,79 @@
+# Luau LSP Integration
+
+RbxSync automatically generates configuration files for [Luau LSP](https://github.com/JohnnyMorganz/luau-lsp), giving you full intellisense, type checking, and autocomplete in VS Code.
+
+## Automatic Setup
+
+When you extract a game, RbxSync creates a `project.json` file in your project root:
+
+```json
+{
+  "name": "YourGame",
+  "tree": {
+    "$path": "src",
+    "Workspace": { "$path": "src/Workspace" },
+    "ReplicatedStorage": { "$path": "src/ReplicatedStorage" },
+    "ServerScriptService": { "$path": "src/ServerScriptService" }
+  }
+}
+```
+
+This file tells Luau LSP how your folder structure maps to Roblox services.
+
+## Features You Get
+
+With Luau LSP configured:
+
+- **Autocomplete**: Full intellisense for Roblox APIs and your own modules
+- **Type Checking**: Catch type errors before testing in Studio
+- **Go to Definition**: Jump to module definitions across your codebase
+- **Hover Info**: See type signatures and documentation on hover
+- **Find References**: Find all usages of a function or variable
+
+## Installing Luau LSP
+
+1. Install the [Luau LSP extension](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.luau-lsp) in VS Code
+2. Extract your game with RbxSync (creates `project.json` automatically)
+3. Open your project folder in VS Code
+4. Luau LSP will detect the project and start providing intellisense
+
+## Manual Sourcemap Generation
+
+If you need to regenerate the sourcemap manually:
+
+```bash
+rbxsync sourcemap
+```
+
+This creates `sourcemap.json` which provides additional path resolution for the LSP.
+
+## Troubleshooting
+
+### LSP Not Working
+
+1. Check that `project.json` exists in your project root
+2. Verify the Luau LSP extension is installed and enabled
+3. Reload VS Code window (`Cmd+Shift+P` → "Reload Window")
+
+### Wrong Service Paths
+
+If autocomplete suggests wrong paths, your `project.json` may be out of date. Re-extract or run:
+
+```bash
+rbxsync sourcemap --regenerate
+```
+
+### Rojo Compatibility
+
+If you have an existing `default.project.json` from Rojo, Luau LSP will use that instead. RbxSync's `project.json` uses the same format, so both tools work together.
+
+## VS Code Settings
+
+For the best experience, add to your `.vscode/settings.json`:
+
+```json
+{
+  "luau-lsp.sourcemap.enabled": true,
+  "luau-lsp.types.roblox": true
+}
+```


### PR DESCRIPTION
## Summary
Two documentation improvements for v1.2:

### RBXSYNC-20: Luau LSP Integration
New page `docs/vscode/luau-lsp.md` covering:
- Automatic `project.json` generation after extraction
- Luau LSP setup and features
- Troubleshooting guide
- VS Code settings

### RBXSYNC-10: Better Extract Explanation  
Improved `docs/getting-started/quick-start.md`:
- Table showing what gets extracted (scripts → .luau, parts → .rbxm, etc.)
- Example directory structure
- When to use extraction
- Links to LSP docs

## Test plan
- [ ] Preview docs site locally with `npm run dev` in docs/
- [ ] Verify links work

Fixes RBXSYNC-10, RBXSYNC-20

---
Generated with [Claude Code](https://claude.com/claude-code)