### PR TITLE
fix(server): Auto-detect Wally packages and sync to Studio

### DIFF
--- a/rbxsync-server/src/file_watcher.rs
+++ b/rbxsync-server/src/file_watcher.rs
@@ -51,9 +51,13 @@ impl FileWatcherState {
 }
 
 /// Start the file watcher for a project directory
+///
+/// If `sync_packages` is true, Wally package changes will be included in file sync.
+/// By default, packages are excluded from file watching.
 pub async fn start_file_watcher(
     project_dir: String,
     state: Arc<RwLock<FileWatcherState>>,
+    sync_packages: bool,
 ) -> anyhow::Result<()> {
     // Check if already watching
     {
@@ -196,9 +200,9 @@ pub async fn start_file_watcher(
                                 continue;
                             }
 
-                            // Skip package paths (Wally packages should not be synced from filesystem)
-                            if is_package_path(&path) {
-                                tracing::trace!("Skipping package path: {:?}", path);
+                            // Skip package paths unless sync_packages is enabled
+                            if !sync_packages && is_package_path(&path) {
+                                tracing::trace!("Skipping package path (sync_packages=false): {:?}", path);
                                 continue;
                             }
 


### PR DESCRIPTION
## Summary

- Fixes Wally packages not syncing to Studio (reported by zBrick20)
- `read_tree` now auto-detects Packages folder and includes packages even without explicit config
- File watcher now respects `packages.excludeFromWatch` config option

## Changes

1. **read_tree endpoint** (`lib.rs`):
   - Changed `packages_enabled` default from `false` to auto-detect if Packages folder exists
   - Now zero-config friendly - packages sync to Studio by default if folder exists

2. **file_watcher** (`file_watcher.rs`):
   - Added `sync_packages` parameter to control whether package changes trigger sync
   - Respects `packages.excludeFromWatch` config (default: true for backwards compat)
   - Set `excludeFromWatch: false` in rbxsync.json to enable auto-sync of package changes

## Usage

**Zero-config (default):** Packages folder is included in manual syncs automatically.

**Auto-sync packages:** Add to `rbxsync.json`:
```json
{
  "packages": {
    "excludeFromWatch": false
  }
}
```

Fixes RBXSYNC-40

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] Manual test: Create Packages folder, verify it syncs to Studio
- [ ] Manual test: Set excludeFromWatch: false, verify file changes sync


🤖 Generated with [Claude Code](https://claude.com/claude-code)