### PR TITLE
docs: LinkedIn post drafts for beta tester outreach

### DIFF
--- a/.claude/reports/linkedin-beta-testers.md
+++ b/.claude/reports/linkedin-beta-testers.md
@@ -1,0 +1,139 @@
+# LinkedIn Beta Testers Outreach - RBXSYNC-9
+
+## Short Version (~150 words)
+
+---
+
+**Your Roblox game's source code lives in Studio. That's a problem.**
+
+No git history. No code reviews. No CI/CD. When something breaks in production, you're digging through TeamCreate history hoping to find when it changed.
+
+We built RbxSync to fix this.
+
+It's a bidirectional sync tool that connects Roblox Studio to your local filesystem. Your Luau code lives in git. You edit in VS Code. Changes sync to Studio in real-time.
+
+The result: proper version control, pull requests, and external tooling for Roblox development.
+
+We're looking for professional studios to partner with as beta testers for v1.2.1. You get early access and direct input on the roadmap. We get real-world feedback from teams shipping games at scale.
+
+If your team is tired of "who changed this?" conversations, let's talk.
+
+DM me or comment below.
+
+---
+
+## Long Version (~300 words)
+
+---
+
+**Professional game studios deserve professional tooling. Roblox development hasn't had that—until now.**
+
+Here's the reality: your game's codebase lives inside Studio. There's no real version control. Code reviews happen over Discord screenshots. When production breaks, you're manually diffing scripts trying to find what changed.
+
+TeamCreate is great for collaboration, but it's not source control.
+
+We built RbxSync to bring standard software engineering practices to Roblox development.
+
+**What it does:**
+- Bidirectional sync between Roblox Studio and your local filesystem
+- Full git integration—branches, commits, pull requests, blame
+- VS Code editing with Luau LSP support
+- AI-assisted testing via MCP integration
+
+**What this means for your team:**
+- Actual code reviews before changes hit production
+- Rollback to any point in your game's history
+- Onboard new developers with proper documentation and git history
+- CI/CD pipeline potential (automated testing, staging environments)
+- External editor support for developers who prefer their own tools
+
+**v1.2.1 is releasing soon** with performance improvements for large games, better conflict resolution, and zero-config setup for faster onboarding.
+
+**We're looking for 3-5 professional studios to partner with as beta testers.**
+
+What you get:
+- Early access to new features
+- Direct line to the development team
+- Input on the roadmap based on your team's real needs
+
+What we need:
+- Feedback from teams actively shipping games
+- Real-world usage patterns we can't simulate
+- Honest input on what works and what doesn't
+
+This isn't a sales pitch. We're building something we needed ourselves, and we want to make sure it works for teams like yours.
+
+If you're running a studio and version control has been on your "we should really fix this" list, let's connect.
+
+---
+
+## Suggested Hashtags
+
+**Primary (use 3-5):**
+- #RobloxDev
+- #GameDevelopment
+- #Roblox
+- #GameDev
+- #VersionControl
+
+**Secondary (rotate):**
+- #LuauProgramming
+- #IndieGameDev
+- #GameStudio
+- #DevTools
+- #OpenSource
+
+**LinkedIn-specific:**
+- #StartupLife
+- #BuildInPublic
+- #BetaTesters
+
+## Posting Strategy
+
+**Best times to post:**
+- Tuesday-Thursday, 8-10 AM PST (catches both US coasts and some EU)
+- Avoid weekends for B2B content
+
+**Engagement approach:**
+1. Post short version first as a test
+2. If engagement is good (>1000 impressions, 20+ reactions), post long version 1-2 weeks later
+3. Reply to every comment within 24 hours
+4. Follow up with commenters via DM after 2-3 public exchanges
+
+**Cross-posting:**
+- Roblox DevForum (different tone, more technical)
+- Twitter/X (condensed version)
+- Roblox Discord servers (if allowed)
+
+---
+
+## Follow-up Comment Templates
+
+### For interested studios:
+
+> Thanks for the interest! Would love to learn more about your team's setup. Are you currently using any external tooling, or is everything in Studio? Happy to jump on a quick call to see if we'd be a good fit.
+
+### For technical questions:
+
+> Great question! [Answer the specific question]. If you want to dig deeper, our docs are at [link] or feel free to DM me—happy to walk through the architecture.
+
+### For skeptics ("Studio works fine"):
+
+> Totally fair—Studio has come a long way. For smaller teams or solo devs, it might be all you need. We built this for teams where "who changed this line?" comes up weekly and rolling back a bad deploy means restoring from a backup. If that's not your pain point, you're probably in good shape!
+
+### For "how is this different from Rojo?":
+
+> Rojo is excellent and we owe a lot to that project! The main differences: RbxSync is bidirectional (changes in Studio sync back to files), includes AI tooling via MCP, and is designed for teams doing active development in both Studio and external editors simultaneously. Different use cases, honestly—Rojo is great for "filesystem is source of truth" workflows.
+
+### For pricing questions:
+
+> Still figuring that out, honestly. The core tool will likely stay open source. If we add enterprise features (SSO, audit logs, etc.), those might be paid. But right now we're focused on getting the product right, not the pricing.
+
+---
+
+## Notes
+
+- Keep tone professional but approachable—we're engineers, not marketers
+- Avoid buzzwords: "revolutionary", "game-changing", "disruptive"
+- Be honest about limitations when asked
+- The goal is partnerships, not downloads—quality over quantity


### PR DESCRIPTION
## Summary
- Created LinkedIn post drafts (short and long versions) for recruiting enterprise/studio beta testers
- Added hashtag recommendations and posting strategy
- Included follow-up comment templates for engagement

Fixes RBXSYNC-9

## Test plan
- [x] Review post drafts for professional tone
- [x] Verify word counts approximate targets
- [ ] Have marketing/team review before posting

🤖 Generated with [Claude Code](https://claude.com/claude-code)