### PR TITLE
fix: Correct license field from MIT to proprietary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 version = "1.2.1"
 edition = "2021"
-license = "MIT"
+license = "LicenseRef-Proprietary"
 authors = ["RbxSync Team"]
 repository = "https://github.com/devmarissa/rbxsync"
 


### PR DESCRIPTION
## Summary
- Fixed Cargo.toml license field from `MIT` to `LicenseRef-Proprietary`
- The actual LICENSE file is RbxSync Proprietary License (Smokestack Games)
- This was a metadata mismatch, not an actual license change

Fixes RBXSYNC-48

🤖 Generated with [Claude Code](https://claude.com/claude-code)