### PR TITLE
feat(harness): Add game templates for common genres

### DIFF
--- a/rbxsync-server/src/harness/templates/horror.yaml
+++ b/rbxsync-server/src/harness/templates/horror.yaml
@@ -1,0 +1,166 @@
+# Horror Game Template
+# Pre-defined features for horror games
+
+genre: Horror
+description: Atmospheric horror with tension, scares, and survival elements
+
+features:
+  - name: Atmosphere System
+    description: Dynamic lighting, fog, and ambient audio for tension
+    priority: critical
+    tags: [core, visuals]
+    acceptanceCriteria:
+      - Dark, moody lighting
+      - Fog and particle effects
+      - Ambient sounds and music
+      - Dynamic atmosphere changes
+    complexity: 4
+
+  - name: Flashlight/Light Sources
+    description: Limited light sources the player controls
+    priority: critical
+    tags: [core, gameplay]
+    acceptanceCriteria:
+      - Flashlight can be toggled
+      - Limited battery/fuel
+      - Light affects visibility
+      - Can find batteries/refills
+    complexity: 3
+
+  - name: Objective System
+    description: Tasks players must complete to progress or escape
+    priority: critical
+    tags: [core, progression]
+    acceptanceCriteria:
+      - Clear objectives displayed
+      - Objectives tracked in UI
+      - Completion advances story
+      - Multiple objectives possible
+    complexity: 3
+
+  - name: Chase Mechanics
+    description: Monster/enemy that pursues players
+    priority: critical
+    tags: [core, gameplay]
+    acceptanceCriteria:
+      - Enemy patrols or hunts
+      - Detection triggers chase
+      - Chase music/sounds
+      - Escape mechanics work
+    complexity: 5
+
+  - name: Hiding System
+    description: Spots where players can hide from enemies
+    priority: high
+    tags: [gameplay, survival]
+    dependencies: [Chase Mechanics]
+    acceptanceCriteria:
+      - Hiding spots in environment
+      - Enter/exit hiding animation
+      - Enemies can detect in hiding (skill-based)
+      - Visual indicator of hidden state
+    complexity: 3
+
+  - name: Stamina System
+    description: Limited sprinting with recovery
+    priority: high
+    tags: [gameplay, balance]
+    acceptanceCriteria:
+      - Stamina bar in UI
+      - Sprinting depletes stamina
+      - Stamina regenerates when walking
+      - Exhaustion effects
+    complexity: 2
+
+  - name: Jump Scares
+    description: Scripted and dynamic scare events
+    priority: high
+    tags: [horror, events]
+    acceptanceCriteria:
+      - Scripted scare moments
+      - Audio stingers
+      - Visual effects
+      - Triggered by player location/action
+    complexity: 3
+
+  - name: Item Collection
+    description: Find keys, notes, and items to progress
+    priority: high
+    tags: [gameplay, puzzles]
+    dependencies: [Objective System]
+    acceptanceCriteria:
+      - Items can be picked up
+      - Inventory for key items
+      - Items unlock doors/areas
+      - Notes provide story/clues
+    complexity: 3
+
+  - name: Locked Doors
+    description: Doors that require keys or codes to open
+    priority: high
+    tags: [puzzles, progression]
+    dependencies: [Item Collection]
+    acceptanceCriteria:
+      - Doors show locked status
+      - Keys unlock specific doors
+      - Codes can be entered
+      - Feedback on wrong key/code
+    complexity: 2
+
+  - name: Sound Cues
+    description: Audio indicating enemy proximity or events
+    priority: high
+    tags: [audio, gameplay]
+    dependencies: [Chase Mechanics]
+    acceptanceCriteria:
+      - Footsteps indicate enemy nearby
+      - Heartbeat when in danger
+      - 3D audio positioning
+      - Music intensity scales
+    complexity: 3
+
+  - name: Sanity/Fear Meter
+    description: Player mental state that affects gameplay
+    priority: medium
+    tags: [gameplay, horror]
+    acceptanceCriteria:
+      - Fear increases in darkness/danger
+      - Visual effects at high fear
+      - Gameplay impacts (speed, vision)
+      - Ways to reduce fear
+    complexity: 4
+
+  - name: Death/Game Over
+    description: What happens when the player is caught
+    priority: critical
+    tags: [core, gameplay]
+    dependencies: [Chase Mechanics]
+    acceptanceCriteria:
+      - Death animation/effect
+      - Game over screen
+      - Respawn at checkpoint
+      - Death count tracking
+    complexity: 2
+
+  - name: Multiple Endings
+    description: Different endings based on player choices
+    priority: medium
+    tags: [story, replayability]
+    dependencies: [Objective System]
+    acceptanceCriteria:
+      - Choices tracked during game
+      - Different ending scenes
+      - Ending unlockables
+      - Replay incentive
+    complexity: 4
+
+  - name: Co-op Support
+    description: Multiple players surviving together
+    priority: medium
+    tags: [multiplayer, social]
+    acceptanceCriteria:
+      - Multiple players in game
+      - Shared objectives
+      - Revive mechanics
+      - Voice chat proximity
+    complexity: 5

--- a/rbxsync-server/src/harness/templates/obby.yaml
+++ b/rbxsync-server/src/harness/templates/obby.yaml
@@ -1,0 +1,133 @@
+# Obby Game Template
+# Pre-defined features for obstacle course games
+
+genre: Obby
+description: Navigate challenging obstacle courses with precision platforming
+
+features:
+  - name: Checkpoint System
+    description: Save player progress at checkpoints throughout the obby
+    priority: critical
+    tags: [core, progression]
+    acceptanceCriteria:
+      - Checkpoints save on touch
+      - Players respawn at last checkpoint
+      - Checkpoint progress persists between sessions
+    complexity: 3
+
+  - name: Stage System
+    description: Organize obby into distinct numbered stages
+    priority: critical
+    tags: [core, structure]
+    acceptanceCriteria:
+      - Stages are clearly numbered
+      - Stage boundaries are defined
+      - Stage completion is tracked
+    complexity: 2
+
+  - name: Timer System
+    description: Track completion time for speedrunning
+    priority: high
+    tags: [competitive, ui]
+    dependencies: [Stage System]
+    acceptanceCriteria:
+      - Timer starts at obby beginning
+      - Timer displays in UI
+      - Best times are saved
+    complexity: 2
+
+  - name: Skip Stage
+    description: Allow players to skip difficult stages with currency/passes
+    priority: medium
+    tags: [monetization, accessibility]
+    dependencies: [Stage System]
+    acceptanceCriteria:
+      - Skip button available per stage
+      - Skips cost currency or gamepass
+      - Skipped stages marked differently
+    complexity: 2
+
+  - name: Kill Bricks
+    description: Hazard parts that reset player to checkpoint
+    priority: critical
+    tags: [core, hazards]
+    dependencies: [Checkpoint System]
+    acceptanceCriteria:
+      - Kill bricks reset on touch
+      - Clear visual indicator (red/lava)
+      - Death count tracking
+    complexity: 1
+
+  - name: Moving Platforms
+    description: Platforms that move in patterns
+    priority: high
+    tags: [obstacles, gameplay]
+    acceptanceCriteria:
+      - Platforms move smoothly
+      - Player stays on moving platforms
+      - Multiple movement patterns
+    complexity: 3
+
+  - name: Difficulty Zones
+    description: Visual indication of difficulty (easy/medium/hard sections)
+    priority: medium
+    tags: [ui, visual]
+    dependencies: [Stage System]
+    acceptanceCriteria:
+      - Color coding for difficulty
+      - Difficulty indicated at zone start
+      - UI shows current difficulty
+    complexity: 2
+
+  - name: Stage Leaderboard
+    description: Fastest times per stage and overall
+    priority: medium
+    tags: [competitive, social]
+    dependencies: [Timer System]
+    acceptanceCriteria:
+      - Top times displayed
+      - Personal best tracking
+      - Global and friend filters
+    complexity: 3
+
+  - name: Death Counter
+    description: Track and display total deaths
+    priority: low
+    tags: [stats, ui]
+    dependencies: [Kill Bricks]
+    acceptanceCriteria:
+      - Deaths counted per session
+      - Total deaths saved
+      - Display in stats UI
+    complexity: 1
+
+  - name: Gravity Zones
+    description: Areas with modified gravity for unique challenges
+    priority: medium
+    tags: [obstacles, mechanics]
+    acceptanceCriteria:
+      - Gravity changes in designated areas
+      - Visual indicator of gravity zones
+      - Smooth transitions
+    complexity: 3
+
+  - name: Invisible Obby Mode
+    description: Challenge mode where platforms become invisible
+    priority: low
+    tags: [challenge, endgame]
+    dependencies: [Stage System]
+    acceptanceCriteria:
+      - Toggle for invisible mode
+      - Platforms fade based on setting
+      - Special rewards for completion
+    complexity: 2
+
+  - name: Spectate Mode
+    description: Watch other players attempt the obby
+    priority: low
+    tags: [social, ui]
+    acceptanceCriteria:
+      - Spectate button in UI
+      - Camera follows selected player
+      - Easy to exit spectate
+    complexity: 3

--- a/rbxsync-server/src/harness/templates/rpg.yaml
+++ b/rbxsync-server/src/harness/templates/rpg.yaml
@@ -1,0 +1,165 @@
+# RPG Game Template
+# Pre-defined features for role-playing games
+
+genre: RPG
+description: Adventure, combat, and character progression in an immersive world
+
+features:
+  - name: Combat System
+    description: Core combat mechanics with attacks, skills, and damage
+    priority: critical
+    tags: [core, gameplay]
+    acceptanceCriteria:
+      - Basic attack functionality
+      - Damage calculation system
+      - Combat feedback (animations, sounds)
+      - Enemy AI responds to attacks
+    complexity: 5
+
+  - name: Inventory System
+    description: Store, equip, and manage items and equipment
+    priority: critical
+    tags: [core, ui]
+    acceptanceCriteria:
+      - Items can be picked up
+      - Inventory UI with slots
+      - Items can be equipped/unequipped
+      - Item tooltips with stats
+    complexity: 4
+
+  - name: Quest System
+    description: Accept, track, and complete quests for rewards
+    priority: critical
+    tags: [core, progression]
+    acceptanceCriteria:
+      - NPCs offer quests
+      - Quest log tracks active quests
+      - Quest objectives update in real-time
+      - Rewards given on completion
+    complexity: 5
+
+  - name: Leveling System
+    description: Gain experience and level up for stat increases
+    priority: critical
+    tags: [core, progression]
+    dependencies: [Combat System]
+    acceptanceCriteria:
+      - XP earned from combat/quests
+      - Level up with clear feedback
+      - Stats increase on level up
+      - Level displayed in UI
+    complexity: 3
+
+  - name: Skill Tree
+    description: Unlock and upgrade abilities as you level
+    priority: high
+    tags: [progression, customization]
+    dependencies: [Leveling System]
+    acceptanceCriteria:
+      - Skill points earned on level
+      - Multiple skill paths
+      - Skills have prerequisites
+      - Respec option available
+    complexity: 4
+
+  - name: Equipment System
+    description: Weapons and armor that modify character stats
+    priority: critical
+    tags: [core, items]
+    dependencies: [Inventory System]
+    acceptanceCriteria:
+      - Equipment slots (weapon, armor, etc.)
+      - Equipment modifies stats
+      - Visual appearance changes
+      - Rarity tiers for equipment
+    complexity: 4
+
+  - name: NPC Dialogue
+    description: Interactive dialogue with NPCs
+    priority: high
+    tags: [story, ui]
+    acceptanceCriteria:
+      - Dialogue UI when interacting
+      - Multiple dialogue options
+      - Dialogue progresses story/quests
+      - NPC names and portraits
+    complexity: 3
+
+  - name: Enemy Spawning
+    description: Enemies spawn in designated areas
+    priority: critical
+    tags: [core, gameplay]
+    acceptanceCriteria:
+      - Enemies spawn in zones
+      - Respawn after death
+      - Difficulty scales by zone
+      - Variety of enemy types
+    complexity: 3
+
+  - name: Dungeon System
+    description: Instanced dungeons with bosses and loot
+    priority: high
+    tags: [endgame, gameplay]
+    dependencies: [Combat System, Enemy Spawning]
+    acceptanceCriteria:
+      - Enter dungeon instances
+      - Boss fights with mechanics
+      - Dungeon-exclusive loot
+      - Party support
+    complexity: 5
+
+  - name: Crafting System
+    description: Combine materials to create items
+    priority: medium
+    tags: [gameplay, economy]
+    dependencies: [Inventory System]
+    acceptanceCriteria:
+      - Crafting recipes
+      - Material requirements clear
+      - Crafting stations in world
+      - Recipe discovery
+    complexity: 4
+
+  - name: Party System
+    description: Form parties with other players
+    priority: medium
+    tags: [social, multiplayer]
+    acceptanceCriteria:
+      - Invite players to party
+      - Party UI shows members
+      - Shared XP option
+      - Party chat
+    complexity: 4
+
+  - name: Health/Mana System
+    description: Resource management for combat
+    priority: critical
+    tags: [core, combat]
+    acceptanceCriteria:
+      - Health bar in UI
+      - Mana/energy for skills
+      - Regeneration mechanics
+      - Death and respawn
+    complexity: 2
+
+  - name: Minimap
+    description: Map showing player location and points of interest
+    priority: medium
+    tags: [ui, navigation]
+    acceptanceCriteria:
+      - Minimap in corner of screen
+      - Player position shown
+      - Quest markers on map
+      - Zoom controls
+    complexity: 3
+
+  - name: Fast Travel
+    description: Teleport between discovered locations
+    priority: medium
+    tags: [quality-of-life, navigation]
+    acceptanceCriteria:
+      - Discover waypoints in world
+      - Travel menu UI
+      - Cost or cooldown for travel
+      - Loading transition
+    complexity: 3

--- a/rbxsync-server/src/harness/templates/simulator.yaml
+++ b/rbxsync-server/src/harness/templates/simulator.yaml
@@ -1,0 +1,147 @@
+# Simulator Game Template
+# Pre-defined features for simulator-style games
+
+genre: Simulator
+description: Collect resources, unlock zones, and grow your collection
+
+features:
+  - name: Collection System
+    description: Core loop of collecting resources/items through actions
+    priority: critical
+    tags: [core, gameplay]
+    acceptanceCriteria:
+      - Click/tool to collect items
+      - Items go to inventory
+      - Collection has visual/audio feedback
+    complexity: 3
+
+  - name: Pet System
+    description: Collectible pets that provide bonuses and can be equipped
+    priority: critical
+    tags: [core, collection]
+    acceptanceCriteria:
+      - Pets can be obtained from eggs
+      - Pets have rarity tiers
+      - Pets provide stat bonuses
+      - Multiple pets can be equipped
+    complexity: 5
+
+  - name: Egg Hatching
+    description: Purchase and hatch eggs to obtain pets
+    priority: high
+    tags: [collection, economy]
+    dependencies: [Pet System]
+    acceptanceCriteria:
+      - Eggs available for purchase
+      - Hatching animation
+      - Rarity odds displayed
+      - Duplicate pet handling
+    complexity: 4
+
+  - name: Zone Unlocking
+    description: Progress through zones with increasing difficulty and rewards
+    priority: critical
+    tags: [progression, world]
+    dependencies: [Collection System]
+    acceptanceCriteria:
+      - Zones have requirements to unlock
+      - Later zones have better rewards
+      - Zone progress saves
+    complexity: 3
+
+  - name: Rebirth System
+    description: Prestige mechanic to reset progress for permanent bonuses
+    priority: high
+    tags: [progression, endgame]
+    dependencies: [Zone Unlocking]
+    acceptanceCriteria:
+      - Rebirth requirements clear
+      - Permanent multipliers granted
+      - Rebirth counter displayed
+    complexity: 4
+
+  - name: Backpack/Capacity
+    description: Limited inventory that can be upgraded
+    priority: high
+    tags: [core, progression]
+    dependencies: [Collection System]
+    acceptanceCriteria:
+      - Capacity limits collection
+      - Can upgrade capacity
+      - Visual indicator of fullness
+    complexity: 2
+
+  - name: Sell Area
+    description: Location to sell collected items for currency
+    priority: critical
+    tags: [core, economy]
+    dependencies: [Collection System]
+    acceptanceCriteria:
+      - Clear sell zone location
+      - Items converted to currency
+      - Auto-sell option available
+    complexity: 2
+
+  - name: Tool Upgrades
+    description: Upgrade collection tools for better efficiency
+    priority: high
+    tags: [progression, economy]
+    dependencies: [Collection System]
+    acceptanceCriteria:
+      - Multiple tool tiers
+      - Clear upgrade costs
+      - Tools persist between sessions
+    complexity: 3
+
+  - name: Lucky/Enchant System
+    description: Random bonuses that multiply collection value
+    priority: medium
+    tags: [gameplay, rng]
+    dependencies: [Collection System]
+    acceptanceCriteria:
+      - Random chance for luck bonus
+      - Visual indicator of luck
+      - Luck can be improved
+    complexity: 3
+
+  - name: Trading System
+    description: Trade pets and items with other players
+    priority: medium
+    tags: [social, economy]
+    dependencies: [Pet System]
+    acceptanceCriteria:
+      - Secure trade window
+      - Both players confirm
+      - Trade history logged
+    complexity: 4
+
+  - name: Codes System
+    description: Redeemable codes for free rewards
+    priority: medium
+    tags: [marketing, rewards]
+    acceptanceCriteria:
+      - Code input UI
+      - One-time redemption per code
+      - Clear feedback on redemption
+    complexity: 2
+
+  - name: Daily Rewards
+    description: Login rewards that scale with streak
+    priority: medium
+    tags: [retention, rewards]
+    acceptanceCriteria:
+      - Daily claim button
+      - Streak tracking
+      - Escalating rewards
+    complexity: 2
+
+  - name: Index/Collection Book
+    description: View all discovered pets and items
+    priority: low
+    tags: [collection, ui]
+    dependencies: [Pet System]
+    acceptanceCriteria:
+      - Shows all possible pets
+      - Tracks discovered vs undiscovered
+      - Completion percentage
+    complexity: 2

--- a/rbxsync-server/src/harness/templates/tycoon.yaml
+++ b/rbxsync-server/src/harness/templates/tycoon.yaml
@@ -1,0 +1,115 @@
+# Tycoon Game Template
+# Pre-defined features for tycoon-style games
+
+genre: Tycoon
+description: Build and manage your own business empire
+
+features:
+  - name: Currency System
+    description: Core currency management with earning, spending, and display
+    priority: critical
+    tags: [core, economy]
+    acceptanceCriteria:
+      - Player can earn currency from production
+      - Currency persists between sessions
+      - Currency displayed in UI
+    complexity: 3
+
+  - name: Upgrade System
+    description: Purchase upgrades to improve production and unlock new content
+    priority: critical
+    tags: [core, progression]
+    dependencies: [Currency System]
+    acceptanceCriteria:
+      - Players can view available upgrades
+      - Upgrades have clear costs and effects
+      - Purchased upgrades persist between sessions
+    complexity: 4
+
+  - name: Production System
+    description: Automated resource generation based on owned buildings/machines
+    priority: critical
+    tags: [core, gameplay]
+    dependencies: [Currency System]
+    acceptanceCriteria:
+      - Production generates currency over time
+      - Production rate scales with upgrades
+      - Visual feedback for production
+    complexity: 3
+
+  - name: Rebirth System
+    description: Prestige mechanic to reset progress for permanent bonuses
+    priority: high
+    tags: [progression, endgame]
+    dependencies: [Currency System, Upgrade System]
+    acceptanceCriteria:
+      - Players can rebirth when requirements met
+      - Rebirth grants permanent multiplier
+      - Rebirth counter persists
+    complexity: 4
+
+  - name: Leaderboards
+    description: Global and friend leaderboards for competition
+    priority: medium
+    tags: [social, competitive]
+    dependencies: [Currency System]
+    acceptanceCriteria:
+      - Players can view global rankings
+      - Leaderboard updates periodically
+      - Shows player rank and score
+    complexity: 3
+
+  - name: Tycoon Buttons
+    description: Physical buttons in world to purchase and unlock content
+    priority: high
+    tags: [ui, gameplay]
+    dependencies: [Currency System]
+    acceptanceCriteria:
+      - Buttons show cost and what they unlock
+      - Buttons become available in sequence
+      - Visual/audio feedback on purchase
+    complexity: 2
+
+  - name: Building Placement
+    description: Place buildings/machines in designated areas
+    priority: high
+    tags: [gameplay, construction]
+    dependencies: [Tycoon Buttons]
+    acceptanceCriteria:
+      - Buildings appear when purchased
+      - Buildings have correct position and orientation
+      - Buildings animate/function when placed
+    complexity: 3
+
+  - name: Conveyor System
+    description: Move resources between production stages
+    priority: medium
+    tags: [gameplay, automation]
+    dependencies: [Production System]
+    acceptanceCriteria:
+      - Items move along conveyors
+      - Items reach destinations correctly
+      - Visual clarity of item flow
+    complexity: 4
+
+  - name: Workers/NPCs
+    description: NPC workers that automate tasks
+    priority: low
+    tags: [automation, visual]
+    dependencies: [Production System]
+    acceptanceCriteria:
+      - Workers can be purchased
+      - Workers perform tasks automatically
+      - Workers have idle and working animations
+    complexity: 3
+
+  - name: Offline Progress
+    description: Earn resources while offline
+    priority: medium
+    tags: [progression, quality-of-life]
+    dependencies: [Production System]
+    acceptanceCriteria:
+      - Calculate earnings based on time away
+      - Show summary on return
+      - Cap maximum offline earnings
+    complexity: 3


### PR DESCRIPTION
## Summary
- Add pre-built feature templates for 5 common Roblox game genres (tycoon, obby, simulator, rpg, horror)
- Templates are embedded at compile time and can be applied via harness init with `--template` flag
- Each template includes 10-14 pre-defined features with priorities, tags, acceptance criteria, and dependencies

## Templates
| Genre | Features | Key Systems |
|-------|----------|-------------|
| Tycoon | 10 | Currency, upgrades, production, rebirth, leaderboards |
| Obby | 12 | Checkpoints, stages, timer, skip, kill bricks |
| Simulator | 13 | Collection, pets, zones, rebirth, trading |
| RPG | 14 | Combat, inventory, quests, leveling, dungeons |
| Horror | 14 | Atmosphere, chase, hiding, objectives, fear |

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --package rbxsync-server` passes
- [ ] Test harness init with `--template tycoon` creates features

Fixes RBXSYNC-52

🤖 Generated with [Claude Code](https://claude.com/claude-code)