### PR TITLE
feat(mcp): Add read_properties tool

### DIFF
--- a/plugin/src/init.server.luau
+++ b/plugin/src/init.server.luau
@@ -1543,6 +1543,76 @@ local function handleCommand(command: string, payload: any)
         end
         return { success = true, output = resultStr, result = result }
 
+    elseif command == "read-properties:get" then
+        local path = payload and payload.path
+        if not path then
+            return { success = false, error = "No path provided" }
+        end
+
+        -- Parse the path and find the instance
+        local instance = nil
+        local parts = string.split(path, "/")
+        if #parts == 0 then
+            return { success = false, error = "Invalid path" }
+        end
+
+        -- First part should be a service name (e.g., "Workspace", "ServerScriptService")
+        local serviceName = Serializer.unescapePathSegment(parts[1])
+        local ok, service = pcall(function()
+            return game:GetService(serviceName)
+        end)
+        if not ok or not service then
+            -- Try as direct child of game
+            ok, service = pcall(function()
+                return game:FindFirstChild(serviceName)
+            end)
+            if not ok or not service then
+                return { success = false, error = "Service or root not found: " .. serviceName }
+            end
+        end
+
+        instance = service
+
+        -- Navigate through the rest of the path
+        for i = 2, #parts do
+            local partName = Serializer.unescapePathSegment(parts[i])
+            -- Handle disambiguated names (e.g., "Part~abc123")
+            local baseName, debugIdSuffix = string.match(partName, "^(.+)~([^~]+)$")
+            if baseName then
+                -- Find child with matching name and debugId prefix
+                local found = false
+                for _, child in instance:GetChildren() do
+                    if child.Name == baseName then
+                        local debugId = child:GetDebugId(0)
+                        if string.sub(debugId, 1, #debugIdSuffix) == debugIdSuffix then
+                            instance = child
+                            found = true
+                            break
+                        end
+                    end
+                end
+                if not found then
+                    return { success = false, error = "Instance not found at path segment: " .. partName }
+                end
+            else
+                -- Simple name lookup
+                local child = instance:FindFirstChild(partName)
+                if not child then
+                    return { success = false, error = "Instance not found: " .. partName .. " in " .. instance:GetFullName() }
+                end
+                instance = child
+            end
+        end
+
+        -- Serialize the instance using existing Serializer
+        local apiDump = Reflection.getAPIDump()
+        local serialized = Serializer.serializeInstance(instance, apiDump)
+        if not serialized then
+            return { success = false, error = "Failed to serialize instance" }
+        end
+
+        return { success = true, data = serialized }
+
     elseif command == "insert:model" then
         local assetId = payload and payload.assetId
         if not assetId then

--- a/rbxsync-mcp/src/tools/mod.rs
+++ b/rbxsync-mcp/src/tools/mod.rs
@@ -709,6 +709,23 @@ impl RbxSyncClient {
 
         Ok(resp)
     }
+
+    /// Read properties of an instance at the given path
+    pub async fn read_properties(&self, path: &str) -> anyhow::Result<ReadPropertiesResponse> {
+        let resp = self
+            .client
+            .post(format!("{}/read-properties", self.base_url))
+            .json(&serde_json::json!({
+                "path": path
+            }))
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        Ok(resp)
+    }
 }
 
 // ============================================================================
@@ -799,4 +816,14 @@ pub struct HarnessStatusResponse {
     pub features: Vec<serde_json::Value>,
     pub feature_summary: FeatureSummary,
     pub recent_sessions: Vec<SessionSummary>,
+}
+
+/// Response from read_properties
+#[derive(Debug, Deserialize)]
+pub struct ReadPropertiesResponse {
+    pub success: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
 }


### PR DESCRIPTION
## Summary
- Adds `read_properties` MCP tool to read instance properties from Roblox Studio
- Takes an instance path (e.g., "Workspace/SpawnLocation") and returns className, name, and all serialized properties
- Uses existing `Serializer` module to properly serialize all Roblox types (Vector3, CFrame, Color3, Enum, etc.)

## Changes
- `rbxsync-mcp/src/main.rs`: Added `ReadPropertiesParams` and `read_properties` tool
- `rbxsync-mcp/src/tools/mod.rs`: Added `read_properties` client method and `ReadPropertiesResponse` type
- `rbxsync-server/src/lib.rs`: Added `/read-properties` endpoint with `handle_read_properties` handler
- `plugin/src/init.server.luau`: Added `read-properties:get` command handler

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes (existing warnings only)
- [ ] Manual test with Studio: call `read_properties("Workspace")` and verify output

Fixes RBXSYNC-58

🤖 Generated with [Claude Code](https://claude.com/claude-code)