### PR TITLE
feat(mcp): Add find_instances tool

### DIFF
--- a/plugin/src/init.server.luau
+++ b/plugin/src/init.server.luau
@@ -1641,6 +1641,110 @@ local function handleCommand(command: string, payload: any)
 
         return { success = true, data = serialized }
 
+    elseif command == "find-instances:search" then
+        -- Search for instances matching criteria
+        local className = payload and payload.className
+        local name = payload and payload.name
+        local parent = payload and payload.parent
+        local limit = (payload and payload.limit) or 50
+
+        -- Define services to search
+        local searchRoots = {}
+        if parent then
+            -- Search in specific parent path
+            local parts = string.split(parent, "/")
+            if #parts > 0 then
+                local serviceName = Serializer.unescapePathSegment(parts[1])
+                local ok, service = pcall(function()
+                    return game:GetService(serviceName)
+                end)
+                if ok and service then
+                    local current = service
+                    for i = 2, #parts do
+                        local partName = Serializer.unescapePathSegment(parts[i])
+                        local child = current:FindFirstChild(partName)
+                        if child then
+                            current = child
+                        else
+                            break
+                        end
+                    end
+                    table.insert(searchRoots, current)
+                end
+            end
+        else
+            -- Search all tracked services
+            local trackedServices = {
+                "Workspace", "ReplicatedStorage", "ReplicatedFirst",
+                "ServerScriptService", "ServerStorage", "StarterGui",
+                "StarterPack", "StarterPlayer", "Lighting", "SoundService",
+                "Teams", "Chat", "LocalizationService", "TestService"
+            }
+            for _, serviceName in trackedServices do
+                local service = game:FindFirstChild(serviceName)
+                if service then
+                    table.insert(searchRoots, service)
+                end
+            end
+        end
+
+        -- Convert wildcard pattern to Lua pattern
+        local function wildcardToPattern(pattern)
+            if not pattern then return nil end
+            -- Escape special Lua pattern characters except *
+            local escaped = pattern:gsub("([%.%+%-%?%[%]%^%$%(%)%%])", "%%%1")
+            -- Convert * to .* for matching any characters
+            escaped = escaped:gsub("%*", ".*")
+            return "^" .. escaped .. "$"
+        end
+
+        local namePattern = wildcardToPattern(name)
+
+        -- Collect matching instances
+        local results = {}
+        local count = 0
+
+        for _, root in searchRoots do
+            if count >= limit then break end
+
+            local descendants = root:GetDescendants()
+            for _, desc in descendants do
+                if count >= limit then break end
+
+                -- Check className filter
+                local classMatch = true
+                if className then
+                    classMatch = desc.ClassName == className
+                end
+
+                -- Check name filter (with wildcard support)
+                local nameMatch = true
+                if namePattern then
+                    nameMatch = string.match(desc.Name, namePattern) ~= nil
+                end
+
+                if classMatch and nameMatch then
+                    -- Build path
+                    local pathParts = {}
+                    local current = desc
+                    while current and current ~= game do
+                        table.insert(pathParts, 1, current.Name)
+                        current = current.Parent
+                    end
+                    local path = table.concat(pathParts, "/")
+
+                    table.insert(results, {
+                        className = desc.ClassName,
+                        name = desc.Name,
+                        path = path
+                    })
+                    count = count + 1
+                end
+            end
+        end
+
+        return { success = true, data = { instances = results, count = count } }
+
     elseif command == "insert:model" then
         local assetId = payload and payload.assetId
         if not assetId then

--- a/rbxsync-mcp/src/tools/mod.rs
+++ b/rbxsync-mcp/src/tools/mod.rs
@@ -726,6 +726,32 @@ impl RbxSyncClient {
 
         Ok(resp)
     }
+
+    /// Search for instances matching the given criteria
+    pub async fn find_instances(
+        &self,
+        class_name: Option<&str>,
+        name: Option<&str>,
+        parent: Option<&str>,
+        limit: Option<u32>,
+    ) -> anyhow::Result<FindInstancesResponse> {
+        let resp = self
+            .client
+            .post(format!("{}/find-instances", self.base_url))
+            .json(&serde_json::json!({
+                "className": class_name,
+                "name": name,
+                "parent": parent,
+                "limit": limit.unwrap_or(50)
+            }))
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        Ok(resp)
+    }
 }
 
 // ============================================================================
@@ -826,4 +852,16 @@ pub struct ReadPropertiesResponse {
     pub error: Option<String>,
     #[serde(default)]
     pub data: Option<serde_json::Value>,
+}
+
+/// Response from find_instances
+#[derive(Debug, Deserialize)]
+pub struct FindInstancesResponse {
+    pub success: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub instances: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub count: usize,
 }


### PR DESCRIPTION
## Summary
- Add new MCP tool `find_instances` to search for instances in the game hierarchy
- Supports filtering by className, name (with wildcard `*` support), and parent path
- Respects limit parameter (default 50 results)

## Changes
- **rbxsync-mcp/src/main.rs**: Add `FindInstancesParams` struct and `find_instances` tool handler
- **rbxsync-mcp/src/tools/mod.rs**: Add `FindInstancesResponse` and `find_instances` client method
- **rbxsync-server/src/lib.rs**: Add `/find-instances` route and `handle_find_instances` handler
- **plugin/src/init.server.luau**: Add `find-instances:search` command with wildcard pattern matching

## Test plan
- [ ] Build project with `cargo build`
- [ ] Run tests with `cargo test`
- [ ] Manually test with Roblox Studio to verify:
  - [ ] `find_instances(className="Part")` returns all Parts
  - [ ] `find_instances(name="Spawn*")` returns instances with names starting with "Spawn"
  - [ ] `find_instances(parent="Workspace")` limits search to Workspace descendants
  - [ ] `find_instances(limit=10)` respects the limit parameter

Fixes RBXSYNC-60

🤖 Generated with [Claude Code](https://claude.com/claude-code)