### PR TITLE
feat(vscode): Add icon theme prompt on first install

### DIFF
--- a/rbxsync-vscode/src/extension.ts
+++ b/rbxsync-vscode/src/extension.ts
@@ -39,21 +39,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   initConsole(context);
 
   // Prompt to enable RbxSync icon theme on first install
-  const iconThemePrompted = context.globalState.get<boolean>('iconThemePrompted');
-  if (!iconThemePrompted) {
-    const currentTheme = vscode.workspace.getConfiguration('workbench').get<string>('iconTheme');
-    if (currentTheme !== 'rbxsync-icons') {
-      vscode.window.showInformationMessage(
-        'RbxSync: Enable Roblox class icons for .luau and .rbxjson files?',
-        'Enable Icons',
-        'Not Now'
-      ).then(selection => {
-        if (selection === 'Enable Icons') {
-          vscode.workspace.getConfiguration('workbench').update('iconTheme', 'rbxsync-icons', vscode.ConfigurationTarget.Global);
-        }
-      });
+  const iconThemePromptShown = context.globalState.get('iconThemePromptShown');
+  if (!iconThemePromptShown) {
+    const result = await vscode.window.showInformationMessage(
+      'RbxSync: Enable custom Roblox file icons?',
+      'Yes',
+      'No'
+    );
+    if (result === 'Yes') {
+      await vscode.workspace.getConfiguration().update(
+        'workbench.iconTheme',
+        'rbxsync-icons',
+        vscode.ConfigurationTarget.Global
+      );
     }
-    context.globalState.update('iconThemePrompted', true);
+    await context.globalState.update('iconThemePromptShown', true);
   }
 
   // Set project directory for multi-workspace support


### PR DESCRIPTION
## Summary
- Updates the icon theme prompt shown on first extension install to use the specified implementation
- Uses `iconThemePromptShown` global state key
- Shows 'Yes'/'No' button options
- Uses async/await pattern for proper sequencing

Fixes RBXSYNC-64

## Test plan
- [ ] Install extension fresh (or clear global state)
- [ ] Verify prompt appears on first activate
- [ ] Click 'Yes' - verify icon theme is set to 'rbxsync-icons'
- [ ] Re-activate extension - verify prompt does not appear again

🤖 Generated with [Claude Code](https://claude.com/claude-code)