### PR TITLE
fix: resolve additional clippy warnings and improve version check

### DIFF
--- a/rbxsync-cli/src/main.rs
+++ b/rbxsync-cli/src/main.rs
@@ -410,10 +410,12 @@ fn check_duplicate_installations() {
     let current_version = env!("CARGO_PKG_VERSION");
 
     // Common installation paths to check
+    let home = std::env::var("HOME").unwrap_or_default();
     let paths_to_check = [
-        "/usr/local/bin/rbxsync",
-        "/usr/bin/rbxsync",
-        &format!("{}/.cargo/bin/rbxsync", std::env::var("HOME").unwrap_or_default()),
+        "/usr/local/bin/rbxsync".to_string(),
+        "/usr/bin/rbxsync".to_string(),
+        format!("{}/.cargo/bin/rbxsync", home),
+        format!("{}/.local/bin/rbxsync", home),
     ];
 
     for path_str in &paths_to_check {


### PR DESCRIPTION
## Summary
- Added `~/.local/bin/rbxsync` to duplicate installation detection paths
- Applied clippy auto-fixes for collapsible if statements in lib.rs
- Fixed redundant pattern matching warnings

## Changes
- `rbxsync-cli/src/main.rs`: Added `.local/bin` path to version conflict detection
- `rbxsync-server/src/lib.rs`: Clippy auto-fixes for code style

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy` shows reduced warnings  

🤖 Generated with [Claude Code](https://claude.com/claude-code)