### PR TITLE
Fix: Disable sync/extract/test buttons when not connected

### DIFF
--- a/rbxsync-vscode/package.json
+++ b/rbxsync-vscode/package.json
@@ -71,7 +71,8 @@
       },
       {
         "command": "rbxsync.extract",
-        "title": "RbxSync: Extract"
+        "title": "RbxSync: Extract",
+        "enablement": "rbxsync.connected"
       },
       {
         "command": "rbxsync.undoExtract",
@@ -79,12 +80,14 @@
       },
       {
         "command": "rbxsync.sync",
-        "title": "RbxSync: Sync"
+        "title": "RbxSync: Sync",
+        "enablement": "rbxsync.connected"
       },
       {
         "command": "rbxsync.runTest",
         "title": "RbxSync: Play Test",
-        "icon": "$(play)"
+        "icon": "$(play)",
+        "enablement": "rbxsync.connected"
       },
       {
         "command": "rbxsync.toggleMetadataFiles",
@@ -102,7 +105,8 @@
       {
         "command": "rbxsync.openConsole",
         "title": "RbxSync: Open Console",
-        "icon": "$(terminal)"
+        "icon": "$(terminal)",
+        "enablement": "rbxsync.connected"
       },
       {
         "command": "rbxsync.closeConsole",

--- a/rbxsync-vscode/src/extension.ts
+++ b/rbxsync-vscode/src/extension.ts
@@ -29,6 +29,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const port = config.get<number>('serverPort') || 44755;
   const autoConnect = config.get<boolean>('autoConnect') ?? true;
 
+  // Initialize context variable for command enablement (RBXSYNC-72)
+  vscode.commands.executeCommand('setContext', 'rbxsync.connected', false);
+
   // Initialize components
   client = new RbxSyncClient(port);
 
@@ -86,6 +89,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Listen for connection changes and fetch all places
   client.onConnectionChange(async (state) => {
     if (state.connected) {
+      // Set context variable for command enablement
+      vscode.commands.executeCommand('setContext', 'rbxsync.connected', true);
+
       // Fetch all connected places
       const places = await client.getConnectedPlaces();
       const projectDir = client.projectDir;
@@ -94,6 +100,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       statusBar.updatePlaces(places, projectDir);
       sidebarView.setConnectionStatus('connected', places, projectDir);
     } else {
+      // Clear context variable when disconnected
+      vscode.commands.executeCommand('setContext', 'rbxsync.connected', false);
+
       statusBar.updatePlaces([], '');
       sidebarView.setConnectionStatus('disconnected', [], '');
     }


### PR DESCRIPTION
## Summary
- Adds `rbxsync.connected` context variable that tracks server connection state
- Disables Extract, Sync, Run Test, and Open Console commands in the command palette when the server is not connected
- Improves UX by preventing users from clicking buttons that would just show an error

## Changes
- **package.json**: Added `enablement: "rbxsync.connected"` to Extract, Sync, Run Test, and Open Console commands
- **extension.ts**: Initialize context variable to `false` on activation, update to `true`/`false` when connection status changes

## Test plan
- [ ] Open VS Code without server running
- [ ] Open command palette and search for "RbxSync: Extract" - should be greyed out
- [ ] Open command palette and search for "RbxSync: Sync" - should be greyed out
- [ ] Open command palette and search for "RbxSync: Play Test" - should be greyed out
- [ ] Start the server
- [ ] Verify commands are now enabled in the command palette

Fixes RBXSYNC-72

🤖 Generated with [Claude Code](https://claude.com/claude-code)