### PR TITLE
docs: HTTP requirement for bot testing

### DIFF
--- a/docs/ai-testing.md
+++ b/docs/ai-testing.md
@@ -34,6 +34,11 @@ Before using AI-assisted testing:
    - AI client (Claude Code, Cursor, etc.) configured with RbxSync MCP server
    - See [MCP Setup](/mcp/setup) for configuration details
 
+4. **HTTP Requests enabled** (for interactive bot testing)
+   - Required for: `bot_observe`, `bot_move`, `bot_action`, `bot_query_server`, `bot_wait_for`, `bot_command`
+   - NOT required for: `run_test` (uses script injection)
+   - See [HTTP Requirement](#http-requirement-for-bot-testing) below
+
 ## The Testing Loop
 
 AI-assisted testing follows a cycle:
@@ -313,6 +318,54 @@ These prompts demonstrate how to instruct AI agents for testing:
 ### Performance Testing
 
 > "Check for errors when loading a large inventory. Use run_code to give the player 100 items, then verify the inventory UI displays correctly."
+
+## HTTP Requirement for Bot Testing
+
+Interactive bot testing tools communicate with the game during playtests via HTTP. This requires enabling HTTP requests in your Roblox game settings.
+
+### Which Tools Need HTTP?
+
+| Tool | Requires HTTP | Notes |
+|------|---------------|-------|
+| `run_test` | ❌ No | Uses script injection, works without HTTP |
+| `run_code` | ❌ No | Executes in plugin context, no HTTP needed |
+| `sync_to_studio` | ❌ No | Uses plugin API |
+| `bot_observe` | ✅ Yes | Queries game state via HTTP |
+| `bot_move` | ✅ Yes | Sends movement commands via HTTP |
+| `bot_action` | ✅ Yes | Sends action commands via HTTP |
+| `bot_query_server` | ✅ Yes | Executes server-side code via HTTP |
+| `bot_wait_for` | ✅ Yes | Polls conditions via HTTP |
+| `bot_command` | ✅ Yes | Sends generic commands via HTTP |
+
+### How to Enable HTTP Requests
+
+1. In Roblox Studio, go to **Home** → **Game Settings** (or **File** → **Game Settings**)
+2. Navigate to the **Security** tab
+3. Enable **Allow HTTP Requests**
+4. Click **Save**
+
+::: warning Published Games
+For published games, this setting affects both Studio testing and the live game. HTTP requests are disabled by default for security. Only enable if you understand the implications.
+:::
+
+### Why HTTP is Required
+
+During a playtest, the bot tools need to communicate with the running game server to:
+- Read player state (position, health, inventory)
+- Send movement and action commands
+- Execute server-side Luau code
+- Poll for condition changes
+
+The RbxSync plugin creates HTTP endpoints during playtests that the bot tools call. Without HTTP enabled, these requests will fail with connection errors.
+
+### Troubleshooting HTTP Issues
+
+If bot commands fail with "HTTP request failed" or similar errors:
+
+1. **Verify HTTP is enabled** - Check Game Settings → Security
+2. **Check firewall settings** - Ensure localhost connections are allowed
+3. **Verify playtest is running** - HTTP endpoints only exist during playtests
+4. **Check plugin connection** - Plugin must show green indicator
 
 ## Limitations
 

--- a/docs/bot-testing.md
+++ b/docs/bot-testing.md
@@ -17,6 +17,10 @@ The bot testing system consists of:
 1. RbxSync server running (`rbxsync serve`)
 2. RbxSync plugin installed in Studio
 3. A game open in Studio with a spawn point
+4. **HTTP Requests enabled** (for bot commands)
+   - Go to **Game Settings** → **Security** → Enable **Allow HTTP Requests**
+   - Required for: `bot_observe`, `bot_move`, `bot_action`, `bot_query_server`
+   - NOT required for: `run_test` (uses script injection)
 
 ### Basic Usage
 
@@ -342,6 +346,7 @@ curl -X POST http://localhost:44755/bot/action \
 
 - Bot commands only work during active playtests (F5/F6)
 - The plugin must be connected to the server
+- **HTTP Requests must be enabled** in Game Settings → Security for bot commands to work
 - State observation should be throttled (~10/sec max)
 
 ## TestAssertions Module
@@ -433,6 +438,17 @@ end
 - Verify UI path is correct
 - Ensure UI is visible before clicking
 - Use `bot_command type="ui" command="getVisibleUI"` to debug
+
+### "HTTP request failed" or connection errors
+
+Bot commands communicate with the game via HTTP during playtests.
+
+**Fix:**
+1. Enable HTTP Requests: **Game Settings** → **Security** → **Allow HTTP Requests**
+2. Ensure a playtest is running (F5 in Studio)
+3. Verify plugin is connected (green indicator)
+
+Note: `run_test` does not require HTTP - it uses script injection. Only the interactive `bot_*` commands need HTTP enabled.
 
 ## Best Practices
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -273,6 +273,16 @@ Insert a model from the Roblox marketplace into the game. Uses InsertService:Loa
 
 AI-powered automated gameplay testing tools. Must be called during an active playtest (after `run_test` or manual F5).
 
+::: warning HTTP Required
+All bot tools (`bot_observe`, `bot_move`, `bot_action`, `bot_wait_for`, `bot_command`, `bot_query_server`) require HTTP Requests to be enabled in your game settings.
+
+**To enable:** Game Settings → Security → Allow HTTP Requests
+
+Note: `run_test` does NOT require HTTP - it uses script injection and works without this setting.
+
+See [HTTP Requirement for Bot Testing](/ai-testing#http-requirement-for-bot-testing) for details.
+:::
+
 ### bot_observe
 
 Observe current game state during a playtest. Returns character position, health, inventory, nearby objects/NPCs, and visible UI.


### PR DESCRIPTION
## Summary
- Documents that interactive bot testing tools require HTTP Requests enabled
- Clarifies that `run_test` works without HTTP (uses script injection)
- Explains how to enable HTTP: Game Settings → Security → Allow HTTP Requests

## Changes
- `docs/ai-testing.md`: Added HTTP requirement section with table showing which tools need HTTP
- `docs/mcp/tools.md`: Added warning note to Bot Controller Tools section
- `docs/bot-testing.md`: Updated prerequisites and troubleshooting sections

## Test plan
- [ ] Verify documentation renders correctly in VitePress
- [ ] Confirm links between sections work

Fixes RBXSYNC-78

🤖 Generated with [Claude Code](https://claude.com/claude-code)