### PR TITLE
fix: Service properties sync to new places

### DIFF
--- a/plugin/src/Sync.luau
+++ b/plugin/src/Sync.luau
@@ -36,6 +36,26 @@ local pendingCSGReconstructions: {{path: string, data: any, parent: Instance}} =
 -- Track instances by path for CSG reconstruction
 local instancesByPath: {[string]: Instance} = {}
 
+-- Services that can be accessed via game:GetService()
+-- Used for reliable service lookup instead of FindFirstChild
+local SERVICES: {[string]: boolean} = {
+    Workspace = true,
+    ReplicatedStorage = true,
+    ReplicatedFirst = true,
+    ServerScriptService = true,
+    ServerStorage = true,
+    StarterGui = true,
+    StarterPack = true,
+    StarterPlayer = true,
+    Lighting = true,
+    SoundService = true,
+    Teams = true,
+    Chat = true,
+    LocalizationService = true,
+    TestService = true,
+    MaterialService = true,
+}
+
 -- Reference properties that need deferred resolution
 -- Comprehensive list of all Instance reference properties in Roblox
 local refProps = {
@@ -427,9 +447,18 @@ function Sync.findInstanceAtPath(path: string): Instance?
 
     local parts = string.split(path, "/")
 
-    -- Top-level service case
+    -- Top-level service case - use GetService for services (more reliable than FindFirstChild)
     if #parts == 1 then
-        return game:FindFirstChild(unescapePathSegment(parts[1]))
+        local name = unescapePathSegment(parts[1])
+        if SERVICES[name] then
+            local ok, service = pcall(function()
+                return game:GetService(name)
+            end)
+            if ok and service then
+                return service
+            end
+        end
+        return game:FindFirstChild(name)
     end
 
     -- Walk the tree to find the instance

--- a/plugin/src/init.server.luau
+++ b/plugin/src/init.server.luau
@@ -977,9 +977,18 @@ local function syncCreate(payload: any): {success: boolean, error: string?, skip
             Sync.registerCreated(path, existingInstance)
             return { success = true, skipped = true }
         end
-        -- For services, if not found at path, they probably exist under game
-        local service = game:FindFirstChild(className)
-        if service then
+        -- For services, if not found at path, use GetService (more reliable than FindFirstChild)
+        local ok, service = pcall(function()
+            return game:GetService(className)
+        end)
+        if ok and service then
+            -- Service found, now apply properties if needed
+            local needsUpdate, reasons = Sync.instanceNeedsUpdate(service, data)
+            if needsUpdate then
+                local _, replacedInstance = Sync.updateInstance(service, data)
+                Sync.registerCreated(path, replacedInstance or service)
+                return { success = true, action = "updated", reasons = reasons }
+            end
             Sync.registerCreated(path, service)
             return { success = true, skipped = true }
         end
@@ -1097,7 +1106,16 @@ local function syncUpdate(payload: any): {success: boolean, error: string?, skip
 
     -- Handle immutable classes (services, built-in instances)
     if isImmutableClass(className) then
-        local instance = Sync.findInstanceAtPath(path) or game:FindFirstChild(className)
+        -- Use GetService as fallback for services (more reliable than FindFirstChild)
+        local instance = Sync.findInstanceAtPath(path)
+        if not instance and className ~= "" then
+            local ok, service = pcall(function()
+                return game:GetService(className)
+            end)
+            if ok then
+                instance = service
+            end
+        end
         if instance then
             -- Only update properties, never replace
             local needsUpdate, reasons = Sync.instanceNeedsUpdate(instance, data)


### PR DESCRIPTION
## Summary
- Service properties (StarterPlayer CameraMode, Workspace Gravity, etc.) were not being applied when syncing to a new place
- Services already exist in new places, so the sync logic was incorrectly skipping property updates
- Use `game:GetService()` instead of `game:FindFirstChild()` for more reliable service lookup
- Fixed `syncCreate()` to actually apply properties when finding services via GetService fallback

## Test plan
- [ ] Extract a game with custom StarterPlayer CameraMode (e.g., LockFirstPerson)
- [ ] Create a new Roblox place
- [ ] Sync the extracted files to the new place
- [ ] Verify StarterPlayer.CameraMode is now LockFirstPerson (not the default Classic)
- [ ] Test with other service properties like Workspace.Gravity and Lighting settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)