### PR TITLE
feat(vscode): UI reacts to CLI/MCP commands

### DIFF
--- a/rbxsync-mcp/src/main.rs
+++ b/rbxsync-mcp/src/main.rs
@@ -417,8 +417,8 @@ impl RbxSyncServer {
             return Ok(CallToolResult::success(vec![Content::text("No changes to sync.")]));
         }
 
-        // Apply changes
-        let result = self.client.sync_batch(&operations).await.map_err(|e| mcp_error(e.to_string()))?;
+        // Apply changes (pass project_dir for operation tracking - RBXSYNC-77)
+        let result = self.client.sync_batch(&operations, Some(&params.project_dir)).await.map_err(|e| mcp_error(e.to_string()))?;
 
         // Check if sync was skipped (disabled or extraction in progress)
         if let Some(ref data) = result.data {

--- a/rbxsync-mcp/src/tools/mod.rs
+++ b/rbxsync-mcp/src/tools/mod.rs
@@ -339,12 +339,13 @@ impl RbxSyncClient {
         Ok(())
     }
 
-    pub async fn sync_batch(&self, operations: &[serde_json::Value]) -> anyhow::Result<SyncBatchResponse> {
+    pub async fn sync_batch(&self, operations: &[serde_json::Value], project_dir: Option<&str>) -> anyhow::Result<SyncBatchResponse> {
         let resp = self
             .client
             .post(format!("{}/sync/batch", self.base_url))
             .json(&serde_json::json!({
-                "operations": operations
+                "operations": operations,
+                "projectDir": project_dir
             }))
             .send()
             .await?

--- a/rbxsync-vscode/package-lock.json
+++ b/rbxsync-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbxsync",
-  "version": "1.0.8",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbxsync",
-      "version": "1.0.8",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "axios": "^1.6.0",

--- a/rbxsync-vscode/src/extension.ts
+++ b/rbxsync-vscode/src/extension.ts
@@ -113,6 +113,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     sidebarView.updatePlaces(places, projectDir);
   });
 
+  // Listen for server-initiated operation status changes (RBXSYNC-77)
+  // This makes the UI react to CLI/MCP commands
+  statusBar.onOperationStatusChange((operation) => {
+    sidebarView.handleServerOperation(operation);
+  });
+
   // Register commands
   const commands = [
     vscode.commands.registerCommand('rbxsync.connect', async () => {

--- a/rbxsync-vscode/src/server/client.ts
+++ b/rbxsync-vscode/src/server/client.ts
@@ -167,6 +167,17 @@ export class RbxSyncClient {
     return places.find(p => p.project_dir === this._projectDir);
   }
 
+  // Get current operation status from server (RBXSYNC-77)
+  async getOperationStatus(projectDir?: string): Promise<import('./types').OperationInfo | null> {
+    try {
+      const params = projectDir ? `?projectDir=${encodeURIComponent(projectDir)}` : '';
+      const response = await this.client.get<import('./types').OperationStatusResponse>(`/rbxsync/status${params}`);
+      return response.data.operation || null;
+    } catch (error) {
+      return null;
+    }
+  }
+
   // Link a specific Studio place to this workspace
   async linkStudio(placeId: number): Promise<boolean> {
     if (!this._projectDir) {

--- a/rbxsync-vscode/src/server/types.ts
+++ b/rbxsync-vscode/src/server/types.ts
@@ -147,6 +147,21 @@ export interface PlacesResponse {
   places: PlaceInfo[];
 }
 
+// Operation status for VS Code UI sync (RBXSYNC-77)
+export type OperationType = 'extract' | 'sync' | 'test';
+
+export interface OperationInfo {
+  type: OperationType;
+  project_dir: string;
+  startTime: number;  // Unix timestamp in millis
+  progress?: string;  // Optional progress message
+}
+
+export interface OperationStatusResponse {
+  operation?: OperationInfo | null;
+  operations?: OperationInfo[];
+}
+
 // Test Runner Types
 export interface ConsoleMessage {
   message: string;


### PR DESCRIPTION
## Summary
- Adds `/rbxsync/status` endpoint to server that returns current operation state
- VS Code extension polls `/status` every 500ms when connected
- Updates sidebar and status bar when CLI/MCP operations (extract_game, sync_to_studio) are running

## Problem
When running `extract_game` or `sync_to_studio` via CLI/MCP, the VS Code UI didn't show the operation status. Only UI-initiated operations updated the display.

## Solution
1. **Server side**: Added operation state tracking in AppState (per project_dir) and `/rbxsync/status` endpoint
2. **VS Code side**: StatusBarManager polls the status endpoint and fires callbacks when operation state changes
3. **Sidebar**: Added `handleServerOperation()` method to update UI for server-initiated operations

## Test plan
- [ ] Run `rbxsync serve` and connect VS Code
- [ ] Run `extract_game` via MCP - VS Code should show "Extracting..." spinner
- [ ] Run `sync_to_studio` via MCP - VS Code should show "Syncing..." spinner
- [ ] UI should return to idle state when operation completes

Fixes RBXSYNC-77

🤖 Generated with [Claude Code](https://claude.com/claude-code)