### PR TITLE
fix(plugin): Fix 3 MCP tool bugs

### DIFF
--- a/plugin/src/Reflection.luau
+++ b/plugin/src/Reflection.luau
@@ -322,4 +322,10 @@ function Reflection.getValueTypeName(prop: PropertyInfo): string
     return "unknown"
 end
 
+-- Get the API dump, loading it if not already loaded (Fixes RBXSYNC-81)
+-- This is an alias for loadAPIDump for consistency with other modules
+function Reflection.getAPIDump(): APIDump?
+    return Reflection.loadAPIDump()
+end
+
 return Reflection

--- a/plugin/src/Serializer.luau
+++ b/plugin/src/Serializer.luau
@@ -552,4 +552,23 @@ function Serializer.clearCache()
     table.clear(instancePaths)
 end
 
+-- Get the path for an instance (Fixes RBXSYNC-80)
+-- Uses cached disambiguated path if available, otherwise builds from names
+function Serializer.getPath(instance: Instance): string
+    -- Check cache first
+    local path = instancePaths[instance]
+    if path then
+        return path
+    end
+
+    -- Fallback: Build path manually with escaped names
+    local pathParts = {}
+    local current: Instance? = instance
+    while current and current ~= game do
+        table.insert(pathParts, 1, escapeNameForPath(current.Name))
+        current = current.Parent
+    end
+    return table.concat(pathParts, "/")
+end
+
 return Serializer

--- a/plugin/src/init.server.luau
+++ b/plugin/src/init.server.luau
@@ -2238,7 +2238,7 @@ local function pollLoop()
                             local responseData = {
                                 id = response.id,
                                 success = ok and (result == nil or result.success ~= false),
-                                data = ok and result or {},  -- Never send nil, use empty table
+                                data = ok and (result and result.data) or {},  -- Extract .data from handler result (Fixes RBXSYNC-79)
                                 error = (not ok and tostring(result)) or (result and result.error) or nil,
                             }
                             print("[RbxSync Debug] Sending response for:", response.command, "id:", response.id)


### PR DESCRIPTION
## Summary
- **RBXSYNC-79**: Fix explore_hierarchy returning `? [?]` by extracting `.data` from handler result before sending response to server
- **RBXSYNC-80**: Add missing `Serializer.getPath()` function to build instance paths for find_instances tool
- **RBXSYNC-81**: Add missing `Reflection.getAPIDump()` function as alias for `loadAPIDump()` for read_properties tool

## Root Causes

1. **RBXSYNC-79**: The response sending code was wrapping the handler's result object directly, causing nested `{ success: true, data: { success: true, data: [...] } }` structure. The MCP client expected `data` to contain the tree directly, not a wrapper object.

2. **RBXSYNC-80**: The find_instances handler called `Serializer.getPath(child)` at line 1863, but this function was never defined in the Serializer module.

3. **RBXSYNC-81**: The read_properties handler called `Reflection.getAPIDump()` at line 1654, but the function was named `loadAPIDump()` instead.

## Test plan
- [ ] Test explore_hierarchy MCP tool returns proper tree structure with name/className/childCount
- [ ] Test find_instances MCP tool finds instances without nil errors
- [ ] Test read_properties MCP tool reads instance properties without nil errors

Fixes RBXSYNC-79, RBXSYNC-80, RBXSYNC-81

🤖 Generated with [Claude Code](https://claude.com/claude-code)