### PR TITLE
feat: Add stop_test MCP command

### DIFF
--- a/rbxsync-mcp/src/tools/mod.rs
+++ b/rbxsync-mcp/src/tools/mod.rs
@@ -186,6 +186,15 @@ pub struct TestFinishResponse {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct TestStopResponse {
+    pub success: bool,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct CommandResponse<T> {
     pub success: bool,
     pub data: T,
@@ -471,6 +480,18 @@ impl RbxSyncClient {
             .await?;
 
         Ok(resp.data)
+    }
+
+    pub async fn stop_test(&self) -> anyhow::Result<TestStopResponse> {
+        let resp: TestStopResponse = self
+            .client
+            .post(format!("{}/test/stop", self.base_url))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        Ok(resp)
     }
 
     pub async fn get_diff(&self, project_dir: &str) -> anyhow::Result<DiffResponse> {


### PR DESCRIPTION
## Summary
- Add `stop_test` MCP tool that stops any running playtest
- Add client method and response type for `/test/stop` endpoint
- Update `run_test` description with important workflow instructions

## Changes
- `rbxsync-mcp/src/tools/mod.rs`: Add `TestStopResponse` struct and `stop_test` client method
- `rbxsync-mcp/src/main.rs`: Add `stop_test` MCP tool, update `run_test` description

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes (no new warnings)

Fixes RBXSYNC-86

🤖 Generated with [Claude Code](https://claude.com/claude-code)