### PR TITLE
fix: bot_query_server command format

### DIFF
--- a/rbxsync-mcp/src/main.rs
+++ b/rbxsync-mcp/src/main.rs
@@ -769,11 +769,9 @@ impl RbxSyncServer {
         &self,
         Parameters(params): Parameters<BotQueryServerParams>,
     ) -> Result<CallToolResult, McpError> {
-        // Send as a bot command with queryServer action
+        // Send as a dedicated bot query server command
         let result = self.client
-            .bot_command("query", "queryServer", Some(serde_json::json!({
-                "code": params.code
-            })))
+            .bot_query_server(&params.code)
             .await
             .map_err(|e| mcp_error(e.to_string()))?;
 

--- a/rbxsync-mcp/src/tools/mod.rs
+++ b/rbxsync-mcp/src/tools/mod.rs
@@ -584,6 +584,26 @@ impl RbxSyncClient {
         Ok(resp)
     }
 
+    /// Execute Luau code on the server during playtest
+    pub async fn bot_query_server(
+        &self,
+        code: &str,
+    ) -> anyhow::Result<BotCommandResponse> {
+        let resp = self
+            .client
+            .post(format!("{}/bot/query-server", self.base_url))
+            .json(&serde_json::json!({
+                "code": code
+            }))
+            .timeout(std::time::Duration::from_secs(60))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        Ok(resp)
+    }
+
     // ========================================================================
     // Harness Methods (Multi-session AI game development tracking)
     // ========================================================================


### PR DESCRIPTION
## Summary
- Fixed bot_query_server MCP tool command format to match what BotRunnerServer plugin expects
- Changed from `{type: 'query', command: 'queryServer', args: {code: '...'}}` to `{action: 'queryServer', code: '...'}`
- Added dedicated `/bot/query-server` endpoint in server

## Test plan
- [ ] Run playtest with a game that uses bot_query_server
- [ ] Verify server code execution works correctly
- [ ] Check BotRunnerServer logs for successful queryServer handling

Fixes RBXSYNC-85

🤖 Generated with [Claude Code](https://claude.com/claude-code)