### PR TITLE
feat: Multi-Studio workspace support

### DIFF
--- a/rbxsync-vscode/package.json
+++ b/rbxsync-vscode/package.json
@@ -129,6 +129,17 @@
         "command": "rbxsync.toggleCat",
         "title": "RbxSync: Toggle Cat",
         "icon": "$(heart)"
+      },
+      {
+        "command": "rbxsync.linkToStudio",
+        "title": "RbxSync: Link to Studio",
+        "icon": "$(link)",
+        "enablement": "rbxsync.connected"
+      },
+      {
+        "command": "rbxsync.unlinkFromStudio",
+        "title": "RbxSync: Unlink from Studio",
+        "icon": "$(debug-disconnect)"
       }
     ],
     "viewsContainers": {
@@ -200,6 +211,18 @@
           "type": "boolean",
           "default": false,
           "description": "Generate project.json for Luau LSP compatibility"
+        },
+        "rbxsync.linkedStudioId": {
+          "type": ["number", "null"],
+          "default": null,
+          "description": "Place ID of the Studio instance linked to this workspace. Null means no studio is linked.",
+          "scope": "window"
+        },
+        "rbxsync.linkedStudioSessionId": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "Session ID of the linked Studio instance (for unpublished places with PlaceId=0)",
+          "scope": "window"
         }
       }
     },


### PR DESCRIPTION
## Summary
- Enable per-workspace Studio linking for multi-game workflows
- Each VS Code workspace can be linked to ONE specific Studio instance
- Link is stored in workspace settings (`.vscode/settings.json`) for persistence
- Sidebar filters to only show the linked Studio when one is selected
- Added "Link to Studio" and "Unlink from Studio" commands in command palette

## Changes
- **package.json**: Added `linkedStudioId` and `linkedStudioSessionId` workspace settings, and new commands
- **extension.ts**: Register new link/unlink commands and initialize linked studio on startup
- **client.ts**: Add workspace settings-based link management with quick pick UI
- **sidebarWebview.ts**: Add link status bar UI, filtering, and header indicator

## How It Works
1. Open VS Code in your project folder
2. Connect to RbxSync server (shows all connected Studios)
3. Use "RbxSync: Link to Studio" command or click "Link" in sidebar
4. Select which Studio instance to link to this workspace
5. Sidebar now filters to show only the linked Studio
6. All sync/extract/test operations target the linked Studio
7. Use "Unlink" to see all Studios again

## Test plan
- [ ] Open VS Code workspace and connect to server with multiple Studios
- [ ] Use "Link to Studio" command and verify quick pick shows all Studios
- [ ] Select a Studio and verify sidebar shows only that Studio
- [ ] Verify `.vscode/settings.json` contains `linkedStudioId` setting
- [ ] Close and reopen VS Code - verify link persists
- [ ] Click "Unlink" and verify all Studios are visible again
- [ ] Test with unpublished place (PlaceId=0) using session ID

Fixes RBXSYNC-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)