### PR TITLE
chore: Build cleanup and v1.3.0 standardization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,12 +26,11 @@ game_project_new/
 test-*/
 testing/
 
-# Plugin build artifacts in wrong locations
-plugin/*.rbxm
+# Build outputs
+build/
 *.rbxm
-
-# Build artifacts (keep in build/ only)
-build/*.vsix
+*.vsix
+!plugin/RbxSync.rbxm
 
 # Local config
 .mcp.json


### PR DESCRIPTION
Fixes RBXSYNC-88

## Summary
- Updated .gitignore for build outputs (build/, *.rbxm, *.vsix)
- Kept exception for plugin/RbxSync.rbxm (the actual plugin file)
- Verified all versions are already at 1.3.0 (Cargo.toml workspace + VS Code extension)

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo clippy` passes (only minor style warnings)

---
Generated with [Claude Code](https://claude.com/claude-code)