### PR TITLE
Fix: Remove all obfuscation from plugin code

### DIFF
--- a/plugin/src/BotRunnerServerSource.luau
+++ b/plugin/src/BotRunnerServerSource.luau
@@ -37,12 +37,8 @@ end
 print("[BotRunner:Server] HTTP access confirmed!")
 
 -- Enable LoadStringEnabled for server-side code execution (queryServer)
--- This is required for _0xe1() to work in the queryServer command
+-- This is required for loadstring() to work in the queryServer command
 local ServerScriptService = game:GetService("ServerScriptService")
-
--- Runtime functions accessed via environment (strings encoded at build time)
-local _0x7f = getfenv(0)
-local _0xe1 = _0x7f["loadstring"]
 
 local loadStringOk, loadStringErr = pcall(function()
 	if not ServerScriptService.LoadStringEnabled then
@@ -225,10 +221,10 @@ local function handleCommandOnServer(cmd, cmdId)
 		print("[BotRunner:Server] Executing queryServer:", string.sub(code, 1, 50) .. "...")
 
 		-- Try with "return" wrapper first for expressions
-		local fn, loadErr = _0xe1("return " .. code)
+		local fn, loadErr = loadstring("return " .. code)
 		if not fn then
 			-- Try without wrapper for statements
-			fn, loadErr = _0xe1(code)
+			fn, loadErr = loadstring(code)
 		end
 
 		if fn then
@@ -269,7 +265,7 @@ local function handleCommandOnServer(cmd, cmdId)
 		print("[BotRunner:Server] waitForServer starting, timeout:", timeout)
 
 		-- Compile condition
-		local condFn, loadErr = _0xe1("return " .. condition)
+		local condFn, loadErr = loadstring("return " .. condition)
 		if not condFn then
 			reportResult(cmdId, {
 				success = false,

--- a/plugin/src/init.server.luau
+++ b/plugin/src/init.server.luau
@@ -24,12 +24,7 @@ local CHUNK_SIZE = 200 -- instances per chunk (Roblox HttpService has 1MB limit)
 local PLUGIN_VERSION = "1.2.1" -- Current plugin version (update on release)
 local UPDATE_CHECK_INTERVAL = 86400 -- Check for updates once per 24 hours
 
--- Runtime functions accessed via environment (strings encoded at build time)
-local _0x9a = getfenv(0)
-local _0xf3 = _0x9a["loadstring"]
-local _0xb7 = _0x9a["getfenv"]
-local _0xc2 = _0x9a["setfenv"]
-local _0xd8 = "LoadAsset"
+-- Runtime functions (used for code execution features)
 
 -- Load modules (modules are children of this script in the bundled .rbxm)
 local Reflection = require(script.Reflection)
@@ -1573,12 +1568,12 @@ local function handleCommand(command: string, payload: any)
             table.insert(output, table.concat(strs, "\t"))
             oldPrint(...)
         end
-        local fn, loadErr = _0xf3(code)
+        local fn, loadErr = loadstring(code)
         if not fn then
             return { success = false, error = "Syntax error: " .. tostring(loadErr), output = "" }
         end
-        local env = setmetatable({ print = capturePrint }, { __index = _0xb7() })
-        _0xc2(fn, env)
+        local env = setmetatable({ print = capturePrint }, { __index = getfenv() })
+        setfenv(fn, env)
         local ok, result = pcall(fn)
         if not ok then
             return { success = false, error = "Runtime error: " .. tostring(result), output = table.concat(output, "\n") }
@@ -1943,7 +1938,7 @@ local function handleCommand(command: string, payload: any)
 
         local InsertService = game:GetService("InsertService")
         local loadSuccess, model = pcall(function()
-            return InsertService[_0xd8](InsertService, assetId)
+            return InsertService:LoadAsset(assetId)
         end)
         if not loadSuccess then
             return { success = false, error = "Failed to load asset: " .. tostring(model) }


### PR DESCRIPTION
## Summary
- Removes broken obfuscation that caused plugin to crash on load
- Replaces `getfenv(0)["loadstring"]` pattern with direct function calls

## Problem
The obfuscation approach using `getfenv(0)["loadstring"]` doesn't work in Roblox's plugin sandbox - it returns nil, causing:
```
user_RbxSync.rbxm.RbxSync:29: attempt to call a nil value
```

## Changes
- `init.server.luau`: Replace `_0x9a/_0xf3/_0xb7/_0xc2/_0xd8` with direct `loadstring`/`getfenv`/`setfenv`/`LoadAsset` calls
- `BotRunnerServerSource.luau`: Replace `_0x7f/_0xe1` with direct `loadstring` calls

## Why This Is Safe
With the move to website/GitHub distribution (RBXSYNC-109), we no longer need obfuscation to bypass Creator Store static analysis.

## Test Plan
- [ ] Plugin loads in Studio without errors
- [ ] `run_code` MCP tool works
- [ ] Bot testing works

Fixes RBXSYNC-110

🤖 Generated with [Claude Code](https://claude.com/claude-code)