### PR TITLE
Fix: VS Code command 'activityView.focus' not found

### DIFF
--- a/rbxsync-vscode/src/views/statusBar.ts
+++ b/rbxsync-vscode/src/views/statusBar.ts
@@ -76,7 +76,7 @@ export class StatusBarManager {
         this.statusBarItem.color = new vscode.ThemeColor('charts.yellow');
       }
       this.statusBarItem.backgroundColor = undefined;
-      this.statusBarItem.command = 'rbxsync.activityView.focus';
+      this.statusBarItem.command = 'rbxsync.sidebarView.focus';
     } else {
       this.statusBarItem.text = '$(circle-outline) RbxSync';
       this.statusBarItem.tooltip = state.lastError


### PR DESCRIPTION
## Summary
- Fixed status bar command from `rbxsync.activityView.focus` to `rbxsync.sidebarView.focus`
- VS Code auto-generates focus commands based on view ID, which is `rbxsync.sidebarView`

## Test plan
- [x] Click status bar when connected to Studio
- [x] Verify activity view opens without error

Fixes RBXSYNC-115

🤖 Generated with [Claude Code](https://claude.com/claude-code)