### PR TITLE
Fix: Detect playtest end and clear stale test state

### DIFF
--- a/plugin/src/TestRunner.luau
+++ b/plugin/src/TestRunner.luau
@@ -33,6 +33,17 @@ local captureStartTime: number = 0
 -- Start capturing console output
 -- Call this before triggering a play session to capture all output
 function TestRunner.startCapture(): { success: boolean, message: string }
+	-- Auto-recover from stale state: if capturing but game isn't running, reset
+	if isCapturing and not RunService:IsRunning() then
+		warn("[TestRunner] Recovering from stale capture state")
+		isCapturing = false
+		if logConnection then
+			logConnection:Disconnect()
+			logConnection = nil
+		end
+		capturedOutput = {}
+	end
+
 	if isCapturing then
 		return { success = false, message = "Capture already in progress" }
 	end
@@ -421,8 +432,28 @@ function TestRunner.getTestStatus(): {
 	error: string?,
 	result: any?,
 	output: { ConsoleMessage },
-	totalMessages: number
+	totalMessages: number,
+	staleRecovered: boolean?
 }
+	-- Auto-recover from stale state: if test was in progress but game stopped
+	local staleRecovered = false
+	if testInProgress and not RunService:IsRunning() then
+		warn("[TestRunner] Recovering from stale test state in getTestStatus")
+		testInProgress = false
+		testComplete = true
+		testError = testError or "Playtest ended unexpectedly"
+		staleRecovered = true
+		-- Also clean up capture state
+		if isCapturing then
+			isCapturing = false
+			if logConnection then
+				logConnection:Disconnect()
+				logConnection = nil
+			end
+		end
+		cleanupBotScripts()
+	end
+
 	return {
 		inProgress = testInProgress,
 		complete = testComplete,
@@ -430,6 +461,7 @@ function TestRunner.getTestStatus(): {
 		result = testResult,
 		output = capturedOutput,
 		totalMessages = #capturedOutput,
+		staleRecovered = staleRecovered,
 	}
 end
 


### PR DESCRIPTION
## Summary
- Fixes `run_test` returning 'Capture already in progress' when no test is running
- Server now auto-clears stale playtest state using heartbeat timeout detection
- Plugin now recovers from stale capture state when playtest ends unexpectedly

## Changes
- **Server (`lib.rs`):**
  - Add `clear_stale_playtest_state()` helper that detects 5-second heartbeat timeout
  - Call it before starting new tests to clear stale state
  - Add `/test/playtest-status` endpoint to check current playtest state

- **Plugin (`TestRunner.luau`):**
  - `startCapture()` now checks `RunService:IsRunning()` and auto-recovers from stale state
  - `getTestStatus()` now detects and recovers from stale test state

## Test plan
- [ ] Start a playtest with `run_test`, stop it manually in Studio (F5)
- [ ] Call `run_test` again - should start successfully instead of erroring
- [ ] Check `/test/playtest-status` shows correct state after playtest ends
- [ ] Verify heartbeat timeout detection works (wait 5+ seconds after stopping)

Fixes RBXSYNC-92

🤖 Generated with [Claude Code](https://claude.com/claude-code)