### PR TITLE
Feature: GitHub releases distribution for plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           ```
 
           ### Other Downloads
-          - **RbxSync.rbxm** - Roblox Studio plugin (or install from [Creator Store](https://create.roblox.com/store/asset/89280418878393/RbxSync))
+          - **RbxSync.rbxm** - Roblox Studio plugin
           - **rbxsync-*.vsix** - VS Code extension (or install from [Marketplace](https://marketplace.visualstudio.com/items?itemName=rbxsync.rbxsync))
 
           ## Changes

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -76,11 +76,7 @@ cargo build --release
 
 Choose one option:
 
-**Option A: Roblox Creator Store (Recommended)**
-
-Install from the [Roblox Creator Store](https://create.roblox.com/store/asset/89280418878393/RbxSync).
-
-**Option B: Download from GitHub**
+**Option A: Download from GitHub (Recommended)**
 
 1. Download `RbxSync.rbxm` from [GitHub Releases](https://github.com/devmarissa/rbxsync/releases)
 2. Copy to your plugins folder:
@@ -90,6 +86,13 @@ Install from the [Roblox Creator Store](https://create.roblox.com/store/asset/89
 ::: tip Finding the Windows plugins folder
 Press `Win + R`, paste `%LOCALAPPDATA%\Roblox\Plugins\`, and press Enter.
 :::
+
+**Option B: CLI Install**
+
+If you have the CLI installed, you can download and install the plugin directly:
+```bash
+rbxsync plugin install
+```
 
 **Option C: Build from source**
 
@@ -134,17 +137,16 @@ rbxsync update
 
 ### Update Studio Plugin
 
-**If installed from Creator Store:**
-1. Open Roblox Studio
-2. Go to **Toolbox** → **Inventory** → **My Plugins**
-3. Find RbxSync and click **Update** if available
-4. Restart Studio
-
-**If installed manually:**
+**Using CLI (Recommended):**
 ```bash
-rbxsync build-plugin --install
+rbxsync plugin install
 ```
-Then restart Studio.
+This downloads the latest plugin from GitHub releases and installs it. Then restart Studio.
+
+**Manually:**
+1. Download the latest `RbxSync.rbxm` from [GitHub Releases](https://github.com/devmarissa/rbxsync/releases)
+2. Copy to your plugins folder (same as installation)
+3. Restart Studio
 
 ### Update VS Code Extension
 


### PR DESCRIPTION
## Summary
- Update CLI 'update' command to download binaries from GitHub releases instead of building from source
- Add `rbxsync plugin install` command to download and install the plugin directly from GitHub releases
- Remove Creator Store references from documentation
- Add `--from-source` flag to `rbxsync update` for legacy build-from-source behavior

## Changes
- `.github/workflows/release.yml`: Remove Creator Store reference from release notes
- `docs/getting-started/installation.md`: Make GitHub releases the primary distribution method, remove Creator Store references
- `rbxsync-cli/src/main.rs`: 
  - New async `cmd_update()` that downloads from GitHub releases
  - New `download_plugin_from_github()` helper function
  - Update `cmd_plugin()` to support downloading plugin from GitHub
  - Add `--from-source` flag to preserve legacy behavior

## Test plan
- [ ] Run `rbxsync update` to verify it downloads from GitHub releases
- [ ] Run `rbxsync update --from-source` to verify legacy build behavior still works
- [ ] Run `rbxsync plugin install` to verify it downloads plugin from GitHub
- [ ] Verify release workflow still creates releases with attached assets

Fixes RBXSYNC-109

🤖 Generated with [Claude Code](https://claude.com/claude-code)