### PR TITLE
Fix: explore_hierarchy and find_instances MCP tools

### DIFF
--- a/rbxsync-server/src/lib.rs
+++ b/rbxsync-server/src/lib.rs
@@ -4529,9 +4529,11 @@ async fn handle_read_properties(
     match tokio::time::timeout(timeout, rx.recv()).await {
         Ok(Some(response)) => {
             state.response_channels.write().await.remove(&request_id);
+            // Plugin returns {success, data: {actual_data}}, extract the nested data field
+            let data = response.data.get("data").cloned().unwrap_or(serde_json::Value::Null);
             (StatusCode::OK, Json(serde_json::json!({
                 "success": response.success,
-                "data": response.data,
+                "data": data,
                 "error": response.error
             })))
         }
@@ -4615,11 +4617,13 @@ async fn handle_explore_hierarchy(
     match tokio::time::timeout(timeout, rx.recv()).await {
         Ok(Some(response)) => {
             state.response_channels.write().await.remove(&request_id);
+            // Plugin returns {success, data: {tree_node}}, extract the nested data field
+            let data = response.data.get("data").cloned().unwrap_or(serde_json::Value::Null);
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
                     "success": response.success,
-                    "data": response.data,
+                    "data": data,
                     "error": response.error
                 })),
             )
@@ -4711,11 +4715,13 @@ async fn handle_find_instances(
     match tokio::time::timeout(timeout, rx.recv()).await {
         Ok(Some(response)) => {
             state.response_channels.write().await.remove(&request_id);
+            // Plugin returns {success, data: {instances, total, limited}}, extract the nested data field
+            let data = response.data.get("data").cloned().unwrap_or(serde_json::Value::Null);
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
                     "success": response.success,
-                    "data": response.data,
+                    "data": data,
                     "error": response.error
                 })),
             )


### PR DESCRIPTION
## Summary
- Fixed response parsing for `explore_hierarchy`, `find_instances`, and `read_properties` MCP endpoints
- Plugin returns `{success, data: {actual_data}}` but server was passing entire object as `data` field
- This caused double-nesting: MCP client received `{data: {success, data: {...}}}` instead of `{data: {...}}`
- Tools were showing "? [?]" or empty results due to missing expected fields

## Test plan
- [ ] Verify `explore_hierarchy(path: 'Workspace')` returns properly formatted tree
- [ ] Verify `find_instances(className: 'Part')` returns list of matching instances
- [ ] Verify `read_properties(path: 'Workspace/SpawnLocation')` returns instance properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)