### PR TITLE
Fix: Duplicate plugin detection (RBXSYNC-102)

### DIFF
--- a/rbxsync-core/src/lib.rs
+++ b/rbxsync-core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod types;
 
 // Re-export commonly used types
 pub use obfuscator::{Obfuscator, ObfuscatorConfig, ObfuscationResult};
-pub use plugin_builder::{build_plugin, build_plugin_with_stats, get_studio_plugins_folder, install_plugin, PluginBuildConfig, PluginBuildStats};
+pub use plugin_builder::{build_plugin, build_plugin_with_stats, find_existing_rbxsync_plugin, get_studio_plugins_folder, install_plugin, PluginBuildConfig, PluginBuildStats};
 pub use rojo::{
     find_rojo_project, parse_rojo_project, rojo_to_tree_mapping, RojoError, RojoProject, RojoTree,
 };

--- a/rbxsync-core/src/plugin_builder.rs
+++ b/rbxsync-core/src/plugin_builder.rs
@@ -260,6 +260,29 @@ pub fn get_studio_plugins_folder() -> Option<PathBuf> {
     }
 }
 
+/// Check if an existing RbxSync plugin is already installed (possibly from marketplace)
+/// Returns the path to the existing plugin if found, None otherwise
+pub fn find_existing_rbxsync_plugin() -> Option<PathBuf> {
+    let plugins_folder = get_studio_plugins_folder()?;
+
+    if !plugins_folder.exists() {
+        return None;
+    }
+
+    // Look for any RbxSync*.rbxm files
+    let entries = fs::read_dir(&plugins_folder).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if name.starts_with("RbxSync") && name.ends_with(".rbxm") {
+                return Some(path);
+            }
+        }
+    }
+
+    None
+}
+
 /// Install a plugin to Studio's plugins folder
 pub fn install_plugin(rbxm_path: &Path, plugin_name: &str) -> Result<PathBuf> {
     let plugins_folder =


### PR DESCRIPTION
## Summary
- Detects existing RbxSync plugins before installing to prevent duplicates
- Adds `--force` flag to override marketplace plugin detection
- Provides clear instructions for uninstalling marketplace plugin first

## Changes
- `rbxsync-core/src/plugin_builder.rs`: Add `find_existing_rbxsync_plugin()` helper
- `rbxsync-cli/src/main.rs`: Add `--force` flag and duplicate detection check

## Test plan
- [ ] Run `rbxsync plugin install` when no plugin exists - should install
- [ ] Run `rbxsync plugin install` when RbxSync plugin exists - should warn and skip
- [ ] Run `rbxsync plugin install --force` when plugin exists - should install anyway

Fixes RBXSYNC-102

🤖 Generated with [Claude Code](https://claude.com/claude-code)