### PR TITLE
Fix: read_properties MCP tool returning empty data

### DIFF
--- a/plugin/src/init.server.luau
+++ b/plugin/src/init.server.luau
@@ -2178,7 +2178,7 @@ local function pollLoop()
                             local responseData = {
                                 id = response.id,
                                 success = ok and (result == nil or result.success ~= false),
-                                data = ok and result or {},  -- Return full handler result as data
+                                data = ok and (result and result.data or result) or {},  -- Extract data field if present, otherwise return full result
                                 error = (not ok and tostring(result)) or (result and result.error) or nil,
                             }
                             print("[RbxSync Debug] Sending response for:", response.command, "id:", response.id)


### PR DESCRIPTION
## Summary
- Fixes double-nesting bug in plugin response handling that caused `read_properties`, `explore_hierarchy`, and other MCP tools to return empty data

## Problem
The poll loop was wrapping handler results in `data` even when handlers already returned a `data` field, causing double nesting:
- Handler returns: `{ success: true, data: { className: "Part", ... } }`
- Response was: `{ data: { success: true, data: { className: "Part", ... } } }`
- MCP looked for `data.className` but found `undefined` (it was at `data.data.className`)

## Solution
Extract `result.data` if present, otherwise return the full result:
```lua
-- Before
data = ok and result or {}

-- After  
data = ok and (result and result.data or result) or {}
```

## Test plan
- [x] Verified fix logic with run_code simulation in Studio
- [x] Tested handlers with `data` field return the data directly
- [x] Tested handlers without `data` field return full result
- [x] Tested handlers returning nil return empty table
- [ ] Manual test: restart Studio with new plugin, verify `read_properties` returns data

Fixes RBXSYNC-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)