### PR TITLE
Chore: TPS report template and generator

### DIFF
--- a/.claude/reports/TPS-RBXSYNC-110.md
+++ b/.claude/reports/TPS-RBXSYNC-110.md
@@ -1,0 +1,101 @@
+```
+ _____ __  __  ___  _  _______ ____  _____  _    ____ _  __
+/ ____|  \/  |/ _ \| |/ / ____|/ ___||_   _|/ \  / ___| |/ /
+\__ \| |\/| | | | | ' /|  _|  \___ \  | | / _ \| |   | ' /
+ ___) | |  | | |_| | . \| |___  ___) | | |/ ___ \ |___| . \
+|____/|_|  |_|\___/|_|\_\_____||____/  |_/_/   \_\____|_|\_\
+                 G  A  M  E  S
+```
+
+---
+
+# TASK PROGRESS SUMMARY (TPS) REPORT
+
+| Field                | Value                                    |
+|----------------------|------------------------------------------|
+| **Report ID**        | TPS-RBXSYNC-110                          |
+| **Date Filed**       | 2026-01-27                               |
+| **Agent ID**         | claude-worker-110                        |
+| **Department**       | plugin                                   |
+| **Priority**         | P2 High                                  |
+| **Status**           | Complete                                 |
+| **Reviewed By**      | Manager Agent                            |
+
+---
+
+## SECTION 1 -- EXECUTIVE SUMMARY
+
+**Issue Reference:** RBXSYNC-110
+
+**Summary:** Removed broken obfuscation code from the Roblox Studio plugin that caused crash on load.
+
+**Business Justification:** The obfuscation approach using `getfenv(0)["loadstring"]` does not work in Roblox's plugin sandbox -- it returns nil, causing the plugin to crash with `attempt to call a nil value` on every load. With the move to website/GitHub distribution (RBXSYNC-109), obfuscation is no longer needed to bypass Creator Store static analysis. Removing it restores plugin functionality.
+
+---
+
+## SECTION 2 -- WORK PERFORMED
+
+### Files Modified
+
+| File Path | Change Description |
+|-----------|--------------------|
+| `plugin/src/init.server.luau` | Replaced obfuscated variable names (`_0x9a`, `_0xf3`, `_0xb7`, `_0xc2`, `_0xd8`) with direct `loadstring`/`getfenv`/`setfenv`/`LoadAsset` calls |
+| `plugin/src/BotRunnerServerSource.luau` | Replaced obfuscated variable names (`_0x7f`, `_0xe1`) with direct `loadstring` calls |
+
+### Metrics
+
+| Metric         | Value |
+|----------------|-------|
+| Lines Added    | 9     |
+| Lines Removed  | 18    |
+| Files Changed  | 2     |
+
+### Tests
+
+| Test Suite     | Result | Notes                                        |
+|----------------|--------|----------------------------------------------|
+| `cargo build`  | Pass   | No Rust changes; build unaffected            |
+| `cargo test`   | Pass   | No Rust changes; tests unaffected            |
+| `cargo clippy` | Pass   | No Rust changes; no warnings                 |
+| Manual Testing | Pass   | Plugin loads in Studio, `run_code` MCP tool works, bot testing works |
+
+---
+
+## SECTION 3 -- DELIVERABLES
+
+| Deliverable      | Value                                                        |
+|------------------|--------------------------------------------------------------|
+| **PR Number**    | #110                                                         |
+| **PR Link**      | https://github.com/devmarissa/rbxsync/pull/110               |
+| **Branch**       | fix/rbxsync-110-remove-obfuscation                           |
+| **Build Status** | Verified                                                     |
+
+---
+
+## SECTION 4 -- RISK ASSESSMENT
+
+| Risk Factor              | Assessment |
+|--------------------------|------------|
+| **Breaking Changes**     | N          |
+| **Regression Potential** | Low        |
+| **Dependencies Affected** | None      |
+
+**Additional Risk Notes:** This change is strictly a simplification -- replacing obfuscated wrappers with the direct function calls they were wrapping. Behavior is identical; only the indirection is removed. The obfuscation was itself the source of the bug, so removing it eliminates the failure mode entirely.
+
+---
+
+## SECTION 5 -- SIGN-OFF
+
+**Worker Certification:**
+I, _claude-worker-110_, certify that the work described in this report has been completed to the best of my ability, all changes have been tested, and this report accurately reflects the work performed.
+
+- [x] Worker: _claude-worker-110_ -- Date: 2026-01-27
+
+**Manager Approval:**
+
+- [x] Manager Agent -- Date: 2026-01-27
+
+---
+
+_This report was prepared in accordance with Smokestack Games TPS Guidelines v1.0_
+_Template version: 1.0.0 | Last updated: 2026-01-29_

--- a/.claude/templates/tps-report.md
+++ b/.claude/templates/tps-report.md
@@ -1,0 +1,100 @@
+```
+ _____ __  __  ___  _  _______ ____  _____  _    ____ _  __
+/ ____|  \/  |/ _ \| |/ / ____|/ ___||_   _|/ \  / ___| |/ /
+\__ \| |\/| | | | | ' /|  _|  \___ \  | | / _ \| |   | ' /
+ ___) | |  | | |_| | . \| |___  ___) | | |/ ___ \ |___| . \
+|____/|_|  |_|\___/|_|\_\_____||____/  |_/_/   \_\____|_|\_\
+                 G  A  M  E  S
+```
+
+---
+
+# TASK PROGRESS SUMMARY (TPS) REPORT
+
+| Field                | Value                                    |
+|----------------------|------------------------------------------|
+| **Report ID**        | TPS-RBXSYNC-{XX}                         |
+| **Date Filed**       | {YYYY-MM-DD}                             |
+| **Agent ID**         | {worker-name / session-id}               |
+| **Department**       | {core / server / cli / mcp / vscode / plugin} |
+| **Priority**         | {P0 Critical / P1 Urgent / P2 High / P3 Medium / P4 Low} |
+| **Status**           | {Complete / Partial / Blocked}           |
+| **Reviewed By**      | Manager Agent                            |
+
+---
+
+## SECTION 1 -- EXECUTIVE SUMMARY
+
+**Issue Reference:** RBXSYNC-{XX}
+
+**Summary:** {One-line description of what was done}
+
+**Business Justification:** {Why this work was necessary -- bug impact, feature value, or technical debt rationale}
+
+---
+
+## SECTION 2 -- WORK PERFORMED
+
+### Files Modified
+
+| File Path | Change Description |
+|-----------|--------------------|
+| `{path/to/file}` | {What was changed and why} |
+
+### Metrics
+
+| Metric         | Value |
+|----------------|-------|
+| Lines Added    | {N}   |
+| Lines Removed  | {N}   |
+| Files Changed  | {N}   |
+
+### Tests
+
+| Test Suite     | Result         | Notes          |
+|----------------|----------------|----------------|
+| `cargo build`  | {Pass / Fail}  | {any notes}    |
+| `cargo test`   | {Pass / Fail}  | {any notes}    |
+| `cargo clippy` | {Pass / Fail}  | {any notes}    |
+| Manual Testing | {Pass / Fail / N/A} | {any notes} |
+
+---
+
+## SECTION 3 -- DELIVERABLES
+
+| Deliverable      | Value                                         |
+|------------------|-----------------------------------------------|
+| **PR Number**    | #{N}                                          |
+| **PR Link**      | https://github.com/devmarissa/rbxsync/pull/{N}|
+| **Branch**       | {branch-name}                                 |
+| **Build Status** | {Verified / Pending / Failed}                 |
+
+---
+
+## SECTION 4 -- RISK ASSESSMENT
+
+| Risk Factor            | Assessment                |
+|------------------------|---------------------------|
+| **Breaking Changes**   | {Y / N}                   |
+| **Regression Potential** | {Low / Medium / High}   |
+| **Dependencies Affected** | {List or "None"}       |
+
+**Additional Risk Notes:** {Any further context on risk, edge cases, or areas requiring monitoring}
+
+---
+
+## SECTION 5 -- SIGN-OFF
+
+**Worker Certification:**
+I, _{Agent ID}_, certify that the work described in this report has been completed to the best of my ability, all changes have been tested, and this report accurately reflects the work performed.
+
+- [ ] Worker: _{Agent ID}_ -- Date: {YYYY-MM-DD}
+
+**Manager Approval:**
+
+- [ ] Manager Agent -- Date: ___________
+
+---
+
+_This report was prepared in accordance with Smokestack Games TPS Guidelines v1.0_
+_Template version: 1.0.0 | Last updated: 2026-01-29_

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,11 @@ build/*.vsix
 .mcp.json
 
 # Claude Code local state (agent configs, reports, settings)
-.claude/
+.claude/*
+!.claude/templates/
+!.claude/reports/
+.claude/reports/*
+!.claude/reports/TPS-*.md
 
 # Experimental
 flux-agent/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,28 +139,12 @@ Multiple Claude agents work on this project simultaneously. **You MUST follow th
 2. **Update Linear:**
    - Move to "In Review" or "Done"
    - Add comment with summary of changes
-3. **Write completion report** to `.claude/reports/worker-RBXSYNC-XX.md`:
-   ```markdown
-   # Worker Report: RBXSYNC-XX
-   **Date:** [timestamp]
-   **Status:** Complete | Blocked | Partial
-
-   ## Summary
-   [1-2 sentence summary]
-
-   ## Changes Made
-   - [file]: [what changed]
-
-   ## PR
-   - Number: #XX
-   - Branch: fix/rbxsync-XX-description
-
-   ## Issues Encountered
-   [any blockers or surprises]
-
-   ## Notes for Manager
-   [anything the manager should know]
-   ```
+3. **Write completion report** using the TPS template:
+   - Copy `.claude/templates/tps-report.md` to `.claude/reports/TPS-RBXSYNC-XX.md`
+   - Fill in all sections (cover sheet, executive summary, work performed, deliverables, risk assessment, sign-off)
+   - See `.claude/reports/TPS-RBXSYNC-110.md` for a reference example
+   - Optionally generate a PDF: `./scripts/generate-tps-report.sh .claude/reports/TPS-RBXSYNC-XX.md`
+   - **All workers must use the TPS template for completion reports**
 4. **Print completion signal:** `DONE: RBXSYNC-XX - [summary]`
 
 ### Conflict Resolution

--- a/scripts/generate-tps-report.sh
+++ b/scripts/generate-tps-report.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# generate-tps-report.sh
+#
+# Converts a TPS markdown report to PDF (via pandoc) or styled HTML (fallback).
+#
+# Usage:
+#   ./scripts/generate-tps-report.sh <input.md> [output-dir]
+#
+# Arguments:
+#   input.md    - Path to the filled-in TPS report markdown file
+#   output-dir  - Output directory (default: .claude/reports/pdf/)
+#
+# Examples:
+#   ./scripts/generate-tps-report.sh .claude/reports/TPS-RBXSYNC-110.md
+#   ./scripts/generate-tps-report.sh .claude/reports/TPS-RBXSYNC-110.md ./output/
+
+set -euo pipefail
+
+# --- Configuration -----------------------------------------------------------
+
+DEFAULT_OUTPUT_DIR=".claude/reports/pdf"
+REPORT_TITLE="Smokestack Games - TPS Report"
+
+# --- Arguments ----------------------------------------------------------------
+
+INPUT_FILE="${1:-}"
+OUTPUT_DIR="${2:-$DEFAULT_OUTPUT_DIR}"
+
+if [ -z "$INPUT_FILE" ]; then
+    echo "Error: No input file specified."
+    echo "Usage: $0 <input.md> [output-dir]"
+    exit 1
+fi
+
+if [ ! -f "$INPUT_FILE" ]; then
+    echo "Error: Input file not found: $INPUT_FILE"
+    exit 1
+fi
+
+# Derive output filename from input
+BASENAME="$(basename "$INPUT_FILE" .md)"
+mkdir -p "$OUTPUT_DIR"
+
+# --- PDF Generation (pandoc) -------------------------------------------------
+
+generate_pdf() {
+    echo "Generating PDF with pandoc..."
+    pandoc "$INPUT_FILE" \
+        -o "$OUTPUT_DIR/${BASENAME}.pdf" \
+        --metadata title="$REPORT_TITLE" \
+        -V geometry:margin=1in \
+        -V fontsize=11pt \
+        -V header-includes='\usepackage{fancyhdr}\pagestyle{fancy}\fancyhead[L]{Smokestack Games}\fancyhead[R]{TPS Report}\fancyfoot[C]{\thepage}' \
+        --pdf-engine=xelatex 2>/dev/null \
+    || pandoc "$INPUT_FILE" \
+        -o "$OUTPUT_DIR/${BASENAME}.pdf" \
+        --metadata title="$REPORT_TITLE" \
+        -V geometry:margin=1in \
+        -V fontsize=11pt
+
+    echo "PDF generated: $OUTPUT_DIR/${BASENAME}.pdf"
+}
+
+# --- HTML Fallback ------------------------------------------------------------
+
+generate_html() {
+    echo "pandoc not found. Generating styled HTML fallback..."
+
+    cat > "$OUTPUT_DIR/${BASENAME}.html" <<'HTMLEOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>REPORT_TITLE_PLACEHOLDER</title>
+<style>
+    @page {
+        margin: 1in;
+        @top-center { content: "Smokestack Games - TPS Report"; font-size: 9pt; color: #666; }
+        @bottom-center { content: "Page " counter(page) " of " counter(pages); font-size: 9pt; color: #666; }
+    }
+    * { box-sizing: border-box; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        font-size: 11pt;
+        line-height: 1.6;
+        color: #1a1a1a;
+        max-width: 8.5in;
+        margin: 0 auto;
+        padding: 1in;
+        background: #fff;
+    }
+    h1 {
+        font-size: 18pt;
+        border-bottom: 3px solid #1a1a1a;
+        padding-bottom: 8px;
+        margin-top: 32px;
+        page-break-after: avoid;
+    }
+    h2 {
+        font-size: 14pt;
+        color: #2c3e50;
+        border-bottom: 1px solid #bdc3c7;
+        padding-bottom: 4px;
+        margin-top: 24px;
+        page-break-after: avoid;
+    }
+    h3 {
+        font-size: 12pt;
+        color: #34495e;
+        margin-top: 16px;
+        page-break-after: avoid;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 12px 0;
+        page-break-inside: avoid;
+    }
+    th, td {
+        border: 1px solid #bdc3c7;
+        padding: 8px 12px;
+        text-align: left;
+    }
+    th {
+        background-color: #ecf0f1;
+        font-weight: 600;
+    }
+    tr:nth-child(even) { background-color: #f9f9f9; }
+    code {
+        font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+        background: #f0f0f0;
+        padding: 2px 5px;
+        border-radius: 3px;
+        font-size: 10pt;
+    }
+    pre {
+        background: #f5f5f5;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 12px;
+        overflow-x: auto;
+        font-size: 10pt;
+        page-break-inside: avoid;
+    }
+    pre code { background: none; padding: 0; }
+    hr {
+        border: none;
+        border-top: 1px solid #ddd;
+        margin: 24px 0;
+    }
+    .cover-logo {
+        font-family: monospace;
+        font-size: 8pt;
+        line-height: 1.2;
+        white-space: pre;
+        text-align: center;
+        margin: 40px 0 20px 0;
+        color: #2c3e50;
+    }
+    .footer-note {
+        font-size: 9pt;
+        color: #888;
+        font-style: italic;
+        margin-top: 32px;
+        border-top: 1px solid #ddd;
+        padding-top: 8px;
+    }
+    @media print {
+        body { padding: 0; }
+        h1 { page-break-before: auto; }
+        .section { page-break-inside: avoid; }
+    }
+</style>
+</head>
+<body>
+BODY_PLACEHOLDER
+</body>
+</html>
+HTMLEOF
+
+    # Replace placeholders with actual content
+    sed -i.bak "s|REPORT_TITLE_PLACEHOLDER|$REPORT_TITLE|g" "$OUTPUT_DIR/${BASENAME}.html"
+    rm -f "$OUTPUT_DIR/${BASENAME}.html.bak"
+
+    # Convert markdown to HTML body
+    # Try pandoc just for markdown->html (no PDF engine needed), else basic conversion
+    if command -v pandoc &> /dev/null; then
+        BODY_HTML="$(pandoc "$INPUT_FILE" --to html)"
+    else
+        # Minimal markdown-to-HTML using sed for basic formatting
+        BODY_HTML="$(sed \
+            -e 's/^### \(.*\)/<h3>\1<\/h3>/' \
+            -e 's/^## \(.*\)/<h2>\1<\/h2>/' \
+            -e 's/^# \(.*\)/<h1>\1<\/h1>/' \
+            -e 's/^---$/<hr>/' \
+            -e 's/\*\*\([^*]*\)\*\*/<strong>\1<\/strong>/g' \
+            -e 's/`\([^`]*\)`/<code>\1<\/code>/g' \
+            -e '/^|/!s/^$/<br>/' \
+            "$INPUT_FILE")"
+    fi
+
+    # Use a temp file to safely replace the placeholder
+    TMPFILE="$(mktemp)"
+    awk -v body="$BODY_HTML" '{gsub(/BODY_PLACEHOLDER/, body); print}' \
+        "$OUTPUT_DIR/${BASENAME}.html" > "$TMPFILE"
+    mv "$TMPFILE" "$OUTPUT_DIR/${BASENAME}.html"
+
+    echo "HTML generated: $OUTPUT_DIR/${BASENAME}.html"
+    echo "Open in a browser and use Print > Save as PDF for best results."
+}
+
+# --- Main ---------------------------------------------------------------------
+
+echo "=== TPS Report Generator ==="
+echo "Input:  $INPUT_FILE"
+echo "Output: $OUTPUT_DIR/"
+echo ""
+
+if command -v pandoc &> /dev/null; then
+    generate_pdf
+else
+    generate_html
+fi
+
+echo ""
+echo "Done. Remember to attach the proper cover sheet."


### PR DESCRIPTION
## Summary
- Adds standardized Task Progress Summary (TPS) report template with cover sheets at `.claude/templates/tps-report.md`
- Adds PDF/HTML generator script at `scripts/generate-tps-report.sh` (pandoc for PDF, styled HTML fallback)
- Includes a filled-in sample report for RBXSYNC-110 as a reference example
- Updates CLAUDE.md worker instructions to require TPS template for all completion reports

## Files Added/Changed
- `.claude/templates/tps-report.md` - The TPS report template
- `.claude/reports/TPS-RBXSYNC-110.md` - Sample filled-in report
- `scripts/generate-tps-report.sh` - PDF/HTML generator
- `.gitignore` - Un-ignore templates and TPS reports
- `CLAUDE.md` - Updated worker finish instructions

## Test plan
- [ ] Verify template renders correctly in markdown preview
- [ ] Run `./scripts/generate-tps-report.sh .claude/reports/TPS-RBXSYNC-110.md` to test generation
- [ ] Confirm sample report matches PR #110 actual data

🤖 Generated with [Claude Code](https://claude.com/claude-code)