### PR TITLE
chore: remove Pesto references from website and docs

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -4,7 +4,7 @@ This guide explains how AI coding assistants can use RbxSync to develop, test, a
 
 ## Overview
 
-RbxSync is the only Roblox sync tool with native AI integration. Unlike other tools (Rojo, Argon, Pesto), RbxSync includes:
+RbxSync is the only Roblox sync tool with native AI integration. Unlike other tools (Rojo, Argon), RbxSync includes:
 
 - **MCP (Model Context Protocol)** tools for direct Studio control
 - **Bot testing** capabilities for automated gameplay testing

--- a/website/index.html
+++ b/website/index.html
@@ -5905,14 +5905,10 @@
                         <span class="competitor-pill-name">Argon</span>
                     </button>
                     <button class="competitor-pill" data-column="5">
-                        <img src="https://tr.rbxcdn.com/180DAY-f955c288b7f0f28cd1c8f5e2b56b0d12/420/420/Image/Webp/noFilter" alt="Pesto" class="competitor-pill-logo">
-                        <span class="competitor-pill-name">Pesto</span>
-                    </button>
-                    <button class="competitor-pill" data-column="6">
                         <img src="images/scriptsync.svg" alt="Script Sync" class="competitor-pill-logo">
                         <span class="competitor-pill-name">Script Sync</span>
                     </button>
-                    <button class="competitor-pill" data-column="7">
+                    <button class="competitor-pill" data-column="6">
                         <img src="images/azullogo.png" alt="Azul" class="competitor-pill-logo">
                         <span class="competitor-pill-name">Azul</span>
                     </button>
@@ -5945,12 +5941,6 @@
                             </th>
                             <th class="tool-header">
                                 <div class="tool-header-content">
-                                    <div class="tool-header-logo-wrap"><img src="https://tr.rbxcdn.com/180DAY-f955c288b7f0f28cd1c8f5e2b56b0d12/420/420/Image/Webp/noFilter" alt="Pesto" class="tool-header-logo"></div>
-                                    <span class="tool-header-name">Pesto</span>
-                                </div>
-                            </th>
-                            <th class="tool-header">
-                                <div class="tool-header-content">
                                     <div class="tool-header-logo-wrap"><img src="images/scriptsync.svg" alt="Script Sync" class="tool-header-logo"></div>
                                     <span class="tool-header-name">Script Sync</span>
                                 </div>
@@ -5970,14 +5960,12 @@
                             <td class="col-rbxsync"><span class="exclusive-tag">Exclusive</span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
-                            <td><span class="status-icon partial" title="Sourcemaps only"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16V4z"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                         </tr>
                         <tr>
                             <td><span class="feature-name">E2E testing</span></td>
                             <td class="col-rbxsync"><span class="exclusive-tag">Exclusive</span></td>
-                            <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
@@ -5990,12 +5978,10 @@
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
-                            <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                         </tr>
                         <tr>
                             <td><span class="feature-name"><span class="rbxjson-text">.rbxjson</span> format</span></td>
                             <td class="col-rbxsync"><span class="exclusive-tag">Exclusive</span></td>
-                            <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
@@ -6007,7 +5993,6 @@
                             <td class="col-rbxsync"><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon partial" title="Via syncback"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16V4z"/></svg></span></td>
                             <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
-                            <td><span class="status-icon partial" title="Pro $6.99"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16V4z"/></svg></span></td>
                             <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                         </tr>
@@ -6016,7 +6001,6 @@
                             <td class="col-rbxsync"><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon partial"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16V4z"/></svg></span></td>
                             <td><span class="status-icon partial"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16V4z"/></svg></span></td>
-                            <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                         </tr>
@@ -6025,7 +6009,6 @@
                             <td class="col-rbxsync"><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon partial"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16V4z"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
-                            <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                         </tr>
@@ -6037,7 +6020,6 @@
                             <td><span class="status-icon partial"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16V4z"/></svg></span></td>
                             <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
-                            <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                         </tr>
                         <tr>
                             <td><span class="feature-name">Build .rbxl/.rbxm</span></td>
@@ -6046,12 +6028,10 @@
                             <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
-                            <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
                         </tr>
                         <tr>
                             <td><span class="feature-name">Sourcemap (LSP)</span></td>
                             <td class="col-rbxsync"><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
-                            <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span></td>
                             <td><span class="status-icon no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 12h12"/></svg></span></td>
@@ -6060,7 +6040,7 @@
                     </tbody>
                     <tfoot>
                         <tr class="comparison-legend-row">
-                            <td colspan="7">
+                            <td colspan="6">
                                 <div class="comparison-legend">
                                     <div class="comparison-legend-item">
                                         <span class="status-icon yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span>
@@ -6604,9 +6584,8 @@ Try: <code>help</code>, <code>init</code>, <code>serve</code>, <code>extract</co
             const competitors = {
                 3: { name: 'Rojo', logo: 'https://rojo.space/img/logo.png' },
                 4: { name: 'Argon', logo: 'images/argon.svg' },
-                5: { name: 'Pesto', logo: 'https://tr.rbxcdn.com/180DAY-f955c288b7f0f28cd1c8f5e2b56b0d12/420/420/Image/Webp/noFilter' },
-                6: { name: 'Script Sync', logo: 'images/scriptsync.svg' },
-                7: { name: 'Azul', logo: 'images/azullogo.png' }
+                5: { name: 'Script Sync', logo: 'images/scriptsync.svg' },
+                6: { name: 'Azul', logo: 'images/azullogo.png' }
             };
 
             // Extract feature data from table
@@ -6615,7 +6594,7 @@ Try: <code>help</code>, <code>init</code>, <code>serve</code>, <code>extract</co
                 const rows = table.querySelectorAll('tbody tr');
                 rows.forEach(row => {
                     const cells = row.querySelectorAll('td');
-                    if (cells.length < 7) return;
+                    if (cells.length < 6) return;
 
                     const featureName = cells[0].querySelector('.feature-name')?.textContent || '';
                     const rbxsyncCell = cells[1];
@@ -6625,9 +6604,9 @@ Try: <code>help</code>, <code>init</code>, <code>serve</code>, <code>extract</co
                         rbxsyncCell.querySelector('.status-icon.partial') ? 'partial' : 'no';
 
                     const competitorStatuses = {};
-                    for (let i = 2; i <= 6; i++) {
+                    for (let i = 2; i <= 5; i++) {
                         const cell = cells[i];
-                        const colIndex = i + 1; // columns are 3-7
+                        const colIndex = i + 1; // columns are 3-6
                         competitorStatuses[colIndex] =
                             cell.querySelector('.status-icon.yes') ? 'yes' :
                             cell.querySelector('.status-icon.partial') ? 'partial' : 'no';

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -14,21 +14,15 @@ RbxSync solves the limitations of Rojo and similar tools by offering:
 
 ## Feature Comparison
 
-| Feature | RbxSync | Rojo | Argon | Pesto |
-|---------|---------|------|-------|-------|
-| Two-way sync | Yes | No | Yes | Yes (Pro $6.99) |
-| Full property extraction | Yes | No | Partial | Yes |
-| Build to .rbxl/.rbxm | Yes | Yes | Yes | No |
-| MCP / AI integration | Yes (full control) | No | No | Partial (sourcemaps only) |
-| E2E testing from CLI | Yes | No | No | No |
-| Console streaming | Yes | No | No | No |
-| Multi-IDE support | Yes (OpenVSX) | Yes | Yes | Yes |
-
-**RbxSync advantages over Pesto:**
-- Full MCP integration with bot control (not just sourcemaps)
-- E2E automated gameplay testing
-- Console streaming for AI debugging
-- Build to distributable .rbxl/.rbxm files
+| Feature | RbxSync | Rojo | Argon |
+|---------|---------|------|-------|
+| Two-way sync | Yes | No | Yes |
+| Full property extraction | Yes | No | Partial |
+| Build to .rbxl/.rbxm | Yes | Yes | Yes |
+| MCP / AI integration | Yes (full control) | No | No |
+| E2E testing from CLI | Yes | No | No |
+| Console streaming | Yes | No | No |
+| Multi-IDE support | Yes (OpenVSX) | Yes | Yes |
 
 Developers migrating from Rojo will find RbxSync familiar but more powerful.
 RbxSync uses similar file conventions (.luau scripts, project files) while


### PR DESCRIPTION
Removes all Pesto references from the marketing website comparison table, llms.txt, and docs.

## Changes
- **website/index.html**: Removed Pesto pill button, table header, all table body cells (10 rows), renumbered Script Sync/Azul columns (6->5, 7->6), updated JS competitors object and extractFeatureData bounds, updated footer colspan from 7 to 6
- **website/llms.txt**: Removed Pesto column from comparison table and "RbxSync advantages over Pesto" section
- **docs/ai-instructions.md**: Removed Pesto from the list of compared tools