### PR TITLE
docs: replace rojo references with rbxsync build-plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ cargo build --release
 # Build VS Code extension
 cd rbxsync-vscode && npm install && npm run build
 
-# Build Studio plugin
-rojo build plugin/default.project.json -o build/RbxSync.rbxm
+# Build and install Studio plugin
+rbxsync build-plugin --install
 ```
 
 ## Project Structure

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -25,7 +25,7 @@ This builds `RbxSync.rbxm` and copies it to your Studio plugins folder.
 
 1. Build the plugin:
    ```bash
-   rojo build plugin/default.project.json -o build/RbxSync.rbxm
+   rbxsync build-plugin
    ```
 
 2. Copy `build/RbxSync.rbxm` to:
@@ -174,11 +174,11 @@ MyGame/
 ### Building
 
 ```bash
-# Using rbxsync CLI
+# Using rbxsync CLI (recommended)
 rbxsync build-plugin
 
-# Using Rojo directly
-rojo build plugin/default.project.json -o build/RbxSync.rbxm
+# Using rbxsync CLI with auto-install to Studio plugins folder
+rbxsync build-plugin --install
 ```
 
 ### Testing Changes


### PR DESCRIPTION
## Summary

- Updated `CONTRIBUTING.md` to use `rbxsync build-plugin --install` instead of `rojo build`
- Updated `plugin/README.md` Option 2 to use `rbxsync build-plugin` instead of `rojo build`
- Updated `plugin/README.md` Development section to show `--install` flag instead of rojo fallback

Fixes #135

## Test plan

- [ ] Verify `rbxsync build-plugin --install` works from a fresh clone
- [ ] Confirm no remaining rojo references in CONTRIBUTING.md or plugin/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)