### PR TITLE
docs: use rbxsync build-plugin as primary method in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ cargo build --release
 # Build VS Code extension
 cd rbxsync-vscode && npm install && npm run build
 
-# Build Studio plugin
-rojo build plugin/default.project.json -o build/RbxSync.rbxm
+# Build and install Studio plugin
+rbxsync build-plugin --install
 ```
 
 ## Project Structure

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -21,7 +21,9 @@ rbxsync build-plugin --install
 
 This builds `RbxSync.rbxm` and copies it to your Studio plugins folder.
 
-### Option 2: Manual Install
+### Option 2: Manual Install (using Rojo)
+
+If you already have [Rojo](https://rojo.space) installed, you can build manually:
 
 1. Build the plugin:
    ```bash
@@ -31,6 +33,8 @@ This builds `RbxSync.rbxm` and copies it to your Studio plugins folder.
 2. Copy `build/RbxSync.rbxm` to:
    - **macOS**: `~/Documents/Roblox/Plugins/`
    - **Windows**: `%LOCALAPPDATA%\Roblox\Plugins\`
+
+> **Note:** Option 1 (`rbxsync build-plugin --install`) is preferred — it handles building and installation in one step without requiring Rojo.
 
 ### Option 3: Creator Store
 
@@ -174,10 +178,10 @@ MyGame/
 ### Building
 
 ```bash
-# Using rbxsync CLI
+# Recommended: using rbxsync CLI
 rbxsync build-plugin
 
-# Using Rojo directly
+# Alternative: using Rojo directly (requires Rojo to be installed)
 rojo build plugin/default.project.json -o build/RbxSync.rbxm
 ```
 


### PR DESCRIPTION
## Summary
- Updated `CONTRIBUTING.md` to use `rbxsync build-plugin --install` instead of `rojo build`
- Updated `plugin/README.md` Option 2 to clearly label Rojo as an alternative with a note recommending Option 1
- Updated `plugin/README.md` Development section to label Rojo as alternative

Fixes #135

## Test plan
- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub
- [ ] Verify `plugin/README.md` renders correctly on GitHub
- [ ] Confirm `rbxsync build-plugin --install` command works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Night Shift