### PR TITLE
Fix: bot_move parameter validation (RBXSYNC-138)

### DIFF
--- a/rbxsync-server/src/lib.rs
+++ b/rbxsync-server/src/lib.rs
@@ -4017,6 +4017,18 @@ async fn handle_bot_move(
     State(state): State<Arc<AppState>>,
     Json(req): Json<BotMoveRequest>,
 ) -> impl IntoResponse {
+    // Validate: at least one of position or objectName must be provided
+    let has_object = req.object_name.is_some() || req.object.is_some();
+    if req.position.is_none() && !has_object {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Must provide either 'position' ({x, y, z}) or 'objectName' (string)"
+            })),
+        );
+    }
+
     // Format command for BotController.executeCommand()
     // BotController expects: { type, command, args }
     let command = if req.position.is_some() {


### PR DESCRIPTION
## Summary
- Validates at least one of `position` or `objectName` is provided before sending bot_move command
- Validates `position` has numeric `x`, `y`, `z` fields with clear error example
- Adds server-side validation in `handle_bot_move` as defense-in-depth
- Fixes silent failures when bot_move is called without parameters

## Test plan
- [ ] Call `bot_move` with no parameters → should get clear error about required params
- [ ] Call `bot_move` with invalid position like `{"x": "abc"}` → should get format error
- [ ] Call `bot_move` with valid position `{x: 0, y: 5, z: 0}` → should work normally
- [ ] Call `bot_move` with `objectName: "SpawnLocation"` → should work normally

Fixes RBXSYNC-138

🤖 Generated with [Claude Code](https://claude.com/claude-code)