### PR TITLE
Fix: Reduce stale session log spam during playtest (RBXSYNC-94)

### DIFF
--- a/rbxsync-server/src/lib.rs
+++ b/rbxsync-server/src/lib.rs
@@ -513,8 +513,8 @@ async fn handle_register(
 
         for stale_key in stale_keys {
             if let Some(info) = registry.remove(&stale_key) {
-                tracing::info!(
-                    "Removed stale session for place {}: {} (old key: {})",
+                tracing::debug!(
+                    "Replaced stale session for place {}: {} (old key: {})",
                     req.place_name,
                     info.session_id.unwrap_or_default(),
                     stale_key
@@ -634,7 +634,7 @@ async fn cleanup_stale_registrations(state: &Arc<AppState>) {
 
     for key in &stale_keys {
         if let Some(info) = registry.remove(key) {
-            tracing::info!("Removed stale registration: {} ({})", info.place_name, key);
+            tracing::debug!("Removed stale registration: {} ({})", info.place_name, key);
         }
     }
 }
@@ -1045,7 +1045,7 @@ async fn cleanup_stale_vscode_workspaces(state: &Arc<AppState>) {
 
     for key in &stale_keys {
         workspaces.remove(key);
-        tracing::info!("Removed stale VS Code workspace: {}", key);
+        tracing::debug!("Removed stale VS Code workspace: {}", key);
     }
 }
 


### PR DESCRIPTION
## Summary
- Downgrades 3 stale session/registration/workspace removal log messages from `info` to `debug` level
- These are normal lifecycle events (session rotation on re-register, periodic cleanup) that spam logs during active playtests
- Debug info is still available with `RUST_LOG=debug` for troubleshooting

## Changed logs
1. `Replaced stale session for place X` (on re-register with different session_id)
2. `Removed stale registration: X` (30s heartbeat timeout cleanup)
3. `Removed stale VS Code workspace: X` (30s heartbeat timeout cleanup)

## Test plan
- [ ] Run `rbxsync serve` with default log level during playtest — should no longer see stale session messages
- [ ] Run with `RUST_LOG=debug` — should still see them for debugging

Fixes RBXSYNC-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)