### PR TITLE
chore: add Makefile for streamlined build and install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ build-vscode:
 	cd rbxsync-vscode && npm ci && npm run build && npx vsce package
 
 # Build Roblox Studio plugin (.rbxm)
-build-plugin: build
-	./target/release/rbxsync build-plugin
+build-plugin:
+	cargo run --bin rbxsync -- build-plugin
 
 # Run all quality checks
 check: clippy test fmt


### PR DESCRIPTION
## Summary
- Adds a `Makefile` with targets for building, installing, testing, and linting the project
- Single `make install` command builds and installs the CLI binary
- `make all` builds Rust crates, VS Code extension, and Studio plugin
- `make check` runs clippy, tests, and format checks

## Test plan
- [ ] Verify `make build` compiles all Rust crates
- [ ] Verify `make install` installs the CLI binary
- [ ] Verify `make check` runs clippy + tests + fmt
- [ ] Verify `make help` prints usage info

Fixes RBXSYNC-89

🤖 Generated with [Claude Code](https://claude.com/claude-code)