### PR TITLE
fix: detect duplicate binaries and add doctor command

### DIFF
--- a/rbxsync-cli/src/main.rs
+++ b/rbxsync-cli/src/main.rs
@@ -3129,10 +3129,20 @@ fn find_rbxsync_binaries() -> Vec<(PathBuf, Option<std::time::SystemTime>)> {
     let mut found = Vec::new();
     let mut seen = HashSet::new();
 
+    #[cfg(target_os = "windows")]
+    let binary_name = "rbxsync.exe";
+    #[cfg(not(target_os = "windows"))]
+    let binary_name = "rbxsync";
+
     // Check all PATH entries
     if let Ok(path_var) = std::env::var("PATH") {
-        for dir in path_var.split(':') {
-            let candidate = PathBuf::from(dir).join("rbxsync");
+        #[cfg(target_os = "windows")]
+        let separator = ';';
+        #[cfg(not(target_os = "windows"))]
+        let separator = ':';
+
+        for dir in path_var.split(separator) {
+            let candidate = PathBuf::from(dir).join(binary_name);
             if candidate.exists() {
                 if let Ok(canonical) = candidate.canonicalize() {
                     if seen.insert(canonical.clone()) {
@@ -3148,12 +3158,26 @@ fn find_rbxsync_binaries() -> Vec<(PathBuf, Option<std::time::SystemTime>)> {
 
     // Check common install locations that might not be in PATH
     let home = dirs::home_dir().unwrap_or_default();
-    let extra_locations = [
+
+    #[cfg(not(target_os = "windows"))]
+    let extra_locations = vec![
         PathBuf::from("/usr/local/bin/rbxsync"),
         home.join(".cargo/bin/rbxsync"),
         home.join(".local/bin/rbxsync"),
         home.join(".rbxsync/bin/rbxsync"),
     ];
+
+    #[cfg(target_os = "windows")]
+    let extra_locations = {
+        let mut locs = vec![home.join(".cargo/bin/rbxsync.exe")];
+        if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+            locs.push(PathBuf::from(local_app_data).join("rbxsync").join("rbxsync.exe"));
+        }
+        if let Ok(app_data) = std::env::var("APPDATA") {
+            locs.push(PathBuf::from(app_data).join("rbxsync").join("rbxsync.exe"));
+        }
+        locs
+    };
 
     for loc in &extra_locations {
         if loc.exists() {


### PR DESCRIPTION
## Summary
- Add `rbxsync doctor` command that checks for common issues:
  - Current binary path verification
  - Duplicate rbxsync installations across PATH and common locations
  - Studio plugin installation status
  - Server running status
- Add startup warning on `rbxsync serve` when multiple binaries are detected
- Detection covers `/usr/local/bin`, `~/.cargo/bin`, `~/.local/bin`, `~/.rbxsync/bin`, and all PATH entries

## Test plan
- [ ] Run `rbxsync doctor` with single installation — should show all green
- [ ] Create a second binary in `/tmp` and add to PATH — should detect duplicate
- [ ] Run `rbxsync serve` with duplicate — should show warning before startup
- [ ] Verify removal commands are correct for each platform

Fixes RBXSYNC-90

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Night Shift)