### PR TITLE
chore: add Makefile for streamlined builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+# RbxSync Makefile
+# Streamlines building, testing, and installing all components.
+#
+# Usage:
+#   make build       - Build all Rust crates (debug)
+#   make release     - Build all Rust crates (release)
+#   make install     - Build release + install CLI to PATH
+#   make test        - Run all Rust tests
+#   make clippy      - Run clippy lints
+#   make check       - Run build + test + clippy
+#   make plugin      - Build RbxSync.rbxm plugin
+#   make vscode      - Build VS Code extension (.vsix)
+#   make all         - Build everything (Rust + plugin + VS Code)
+#   make clean       - Clean all build artifacts
+#   make bench       - Run benchmarks
+
+.PHONY: all build release install test clippy check plugin vscode clean bench fmt
+
+# Default: build everything
+all: release plugin vscode
+
+# --- Rust ---
+
+build:
+	cargo build
+
+release:
+	cargo build --release
+
+install: release
+	cargo install --path rbxsync-cli --force
+
+test:
+	cargo test
+
+clippy:
+	cargo clippy -- -D warnings
+
+fmt:
+	cargo fmt
+
+check: build test clippy
+
+# --- Plugin ---
+
+plugin: release
+	./target/release/rbxsync build-plugin
+
+# --- VS Code Extension ---
+
+vscode:
+	cd rbxsync-vscode && npm ci --silent && npm run build && npx vsce package
+
+# --- Benchmarks ---
+
+bench:
+	cargo bench
+
+# --- Docs ---
+
+docs:
+	cd docs && npm install && npm run build
+
+# --- Clean ---
+
+clean:
+	cargo clean
+	rm -f build/RbxSync.rbxm
+	rm -f rbxsync-vscode/*.vsix


### PR DESCRIPTION
## Summary
- Adds a top-level Makefile that consolidates all build commands into a single entry point
- Covers Rust crates, plugin build, VS Code extension, tests, clippy, benchmarks, and docs
- `make all` builds everything; `make install` builds release and installs CLI to PATH

Fixes RBXSYNC-89

## Test plan
- [x] `cargo build` passes in worktree
- [x] `cargo test` passes (19 tests)
- [x] Pre-existing clippy warnings confirmed on master (not introduced by this PR)
- [ ] Verify `make plugin` works with rbxsync binary available
- [ ] Verify `make vscode` works with npm/vsce installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)