### PR TITLE
feat: add Clippy as optional mascot

### DIFF
--- a/rbxsync-vscode/package.json
+++ b/rbxsync-vscode/package.json
@@ -200,6 +200,16 @@
           "type": "boolean",
           "default": true,
           "description": "Generate default.project.json for Luau LSP compatibility after extraction"
+        },
+        "rbxsync.mascot": {
+          "type": "string",
+          "enum": ["sink", "clippy"],
+          "default": "sink",
+          "enumDescriptions": [
+            "Sink the zen cat",
+            "Clippy the helpful paperclip"
+          ],
+          "description": "Choose your RbxSync mascot companion."
         }
       }
     },

--- a/rbxsync-vscode/src/views/sidebarWebview.ts
+++ b/rbxsync-vscode/src/views/sidebarWebview.ts
@@ -1220,178 +1220,364 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
     const vscode = acquireVsCodeApi();
     let state = null;
 
-    // Zen Cat ASCII Art for different moods (detailed 4-line)
-    const CAT_ART = {
-      idle: \` /\\\\_/\\\\
+    // ── Mascot Definition System ──
+    // Each mascot is a data object with art, messages, and quotes.
+    // The active mascot is selected by the rbxsync.mascot VS Code setting.
+
+    const MASCOTS = {
+      sink: {
+        name: 'Sink',
+        art: {
+          idle: \` /\\\\_/\\\\
 ( -.- )
  />♡<\\\\
   ~z~\`,
-      syncing: \` /\\\\_/\\\\
+          syncing: \` /\\\\_/\\\\
 ( o.o )
  />~<\\\\
   ~~~\`,
-      success: \` /\\\\_/\\\\
+          success: \` /\\\\_/\\\\
 ( ^.^ )
  />v<\\\\
 *purr*\`,
-      error: \` /\\\\_/\\\\
+          error: \` /\\\\_/\\\\
 ( >.< )
  />!<\\\\
   ?!?\`
-    };
-
-    // Status indicator text for different moods
-    const CAT_STATUS = {
-      idle: ['~ Napping...', '◦ Dreaming...', '✧ Resting...', '~ Dozing...'],
-      syncing: ['✻ Working...', '◈ Syncing...', '⟳ Pushing...', '✦ Busy...'],
-      success: ['♡ Happy!', '✿ Purrfect!', '★ Done!', '❋ Yay!'],
-      error: ['⚠ Oh no...', '✕ Uh oh...', '◇ Oops...'],
-      thinking: ['✻ Thinking...', '◦ Pondering...', '✧ Hmm...'],
-      connecting: ['◈ Waking...', '✦ Starting...', '⟳ Connecting...'],
-    };
-
-    function updateCatStatus(mood) {
-      const statusEl = document.getElementById('zenCatStatus');
-      if (!statusEl) return;
-      const statuses = CAT_STATUS[mood] || CAT_STATUS.idle;
-      statusEl.textContent = statuses[Math.floor(Math.random() * statuses.length)];
-    }
-
-    // Talking cat faces for animation while typing
-    const CAT_TALK = [
-      \` /\\\\_/\\\\
+        },
+        talk: [
+          \` /\\\\_/\\\\
 ( °o° )
  />~<\\\\
   ...\`,
-      \` /\\\\_/\\\\
+          \` /\\\\_/\\\\
 ( °-° )
  />~<\\\\
   ...\`
-    ];
-
-    // Contextual cat messages by operation type
-    const CAT_MESSAGES = {
-      sync: [
-        "Syncing meow~",
-        "Pushing changes...",
-        "Almost there~",
-        "Uploading scripts...",
-        "Just a moment..."
-      ],
-      extract: [
-        "Extracting meow~",
-        "Grabbing files...",
-        "So many instances!",
-        "Downloading...",
-        "Fetching data~"
-      ],
-      test: [
-        "Testing meow~",
-        "Running checks...",
-        "Paws crossed!",
-        "Executing...",
-        "Let's see~"
-      ],
-      success: [
-        "All done! Purr~",
-        "Meow-velous!",
-        "Nailed it!",
-        "Purrfect!",
-        "Success meow~"
-      ],
-      error: [
-        "Oh no meow!",
-        "Something went wrong...",
-        "Hiss!",
-        "Uh oh...",
-        "Error meow!"
-      ],
-      serverStart: [
-        "Server starting~",
-        "Waking up...",
-        "Stretching...",
-        "Coming online!"
-      ],
-      serverConnected: [
-        "Connected! Purr~",
-        "Ready to go!",
-        "All systems meow!",
-        "Online and cozy~"
-      ],
-      serverStopped: [
-        "Server stopped~",
-        "Taking a nap...",
-        "Zzz...",
-        "Going offline~"
-      ],
-      studioJoined: [
-        "New friend!",
-        "Hello Studio~",
-        "Welcome meow!",
-        "A visitor!"
-      ],
-      studioLeft: [
-        "Bye bye~",
-        "Studio left...",
-        "See you later!",
-        "Gone meow..."
-      ],
-      studioLinked: [
-        "Linked up!",
-        "Connected meow~",
-        "We're bonded!",
-        "Link established!"
-      ],
-      studioUnlinked: [
-        "Unlinked~",
-        "Disconnected...",
-        "Link broken",
-        "Separated meow"
-      ]
+        ],
+        clickFace: \` /\\\\_/\\\\
+( O.O )
+ />!<\\\\
+ meow!\`,
+        eventArt: {
+          connecting: \` /\\\\_/\\\\
+( o.o )
+ />~<\\\\
+  ~~~\`,
+          connected: \` /\\\\_/\\\\
+( ^.^ )
+ />v<\\\\
+*purr*\`,
+          disconnected: \` /\\\\_/\\\\
+( -.- )
+ />♡<\\\\
+  ~z~\`,
+          studioJoined: \` /\\\\_/\\\\
+( o.o )
+ />~<\\\\
+  !!!\`,
+          studioLeft: \` /\\\\_/\\\\
+( ;.; )
+ />~<\\\\
+  ...\`,
+          studioLinked: \` /\\\\_/\\\\
+( ^.^ )
+ />v<\\\\
+ yay!\`,
+          studioUnlinked: \` /\\\\_/\\\\
+( -.- )
+ />~<\\\\
+  ok~\`
+        },
+        statusMessages: {
+          idle: ['~ Napping...', '◦ Dreaming...', '✧ Resting...', '~ Dozing...'],
+          syncing: ['✻ Working...', '◈ Syncing...', '⟳ Pushing...', '✦ Busy...'],
+          success: ['♡ Happy!', '✿ Purrfect!', '★ Done!', '❋ Yay!'],
+          error: ['⚠ Oh no...', '✕ Uh oh...', '◇ Oops...'],
+          thinking: ['✻ Thinking...', '◦ Pondering...', '✧ Hmm...'],
+          connecting: ['◈ Waking...', '✦ Starting...', '⟳ Connecting...'],
+        },
+        operationMessages: {
+          sync: ["Syncing meow~", "Pushing changes...", "Almost there~", "Uploading scripts...", "Just a moment..."],
+          extract: ["Extracting meow~", "Grabbing files...", "So many instances!", "Downloading...", "Fetching data~"],
+          test: ["Testing meow~", "Running checks...", "Paws crossed!", "Executing...", "Let's see~"],
+          success: ["All done! Purr~", "Meow-velous!", "Nailed it!", "Purrfect!", "Success meow~"],
+          error: ["Oh no meow!", "Something went wrong...", "Hiss!", "Uh oh...", "Error meow!"],
+          serverStart: ["Server starting~", "Waking up...", "Stretching...", "Coming online!"],
+          serverConnected: ["Connected! Purr~", "Ready to go!", "All systems meow!", "Online and cozy~"],
+          serverStopped: ["Server stopped~", "Taking a nap...", "Zzz...", "Going offline~"],
+          studioJoined: ["New friend!", "Hello Studio~", "Welcome meow!", "A visitor!"],
+          studioLeft: ["Bye bye~", "Studio left...", "See you later!", "Gone meow..."],
+          studioLinked: ["Linked up!", "Connected meow~", "We're bonded!", "Link established!"],
+          studioUnlinked: ["Unlinked~", "Disconnected...", "Link broken", "Separated meow"]
+        },
+        greetings: [
+          "Welcome back, friend!", "Hello there! Ready to code?", "Hi! Sink is here to help~",
+          "Welcome to RbxSync!", "Hey! Let's build something!", "Good to see you!",
+          "Sink reporting for duty!", "Hello, developer!", "Ready when you are~",
+          "Let's make something cool!", "Sink is happy to see you!", "Welcome! *purrs*",
+          "Hey friend! Let's go~", "Hi hi! Ready to sync?", "Sink says hello!"
+        ],
+        clickMessages: [
+          "Meow!", "Mrrp?", "Purrr~", "*blinks slowly*", "Nya~", "*head bonk*",
+          "Pet me more!", "*kneads paws*", "Prrrrt!", "*tail swish*", "Feed me?",
+          "*chirp chirp*", "So sleepy...", "*stretches*", "Mrow!", "*flops over*",
+          "Treats?", "*ear twitch*", "Mew~", "*purrs loudly*"
+        ],
+        quotes: [
+          "Just breathe.", "Be here now.", "There is only Now.", "Breathe and let be.",
+          "Pay attention.", "Attention!", "What am I?", "Om mani padme hum",
+          "When hungry, eat.", "When tired, sleep.", "You are the sky.", "YOLO",
+          "Who is breathing?", "Focus on your breath.", "Let go of thinking.",
+          "Just be in this moment.", "Do one thing at a time.", "Do dishes, rake leaves.",
+          "Chop wood, carry water.", "What you think, you become.", "Nothing is permanent.",
+          "Seek the mind.", "You are awareness.", "There is only the Present.",
+          "Clean the floor with love.", "Drink your tea slowly.", "Attend the moment.",
+          "We have only now.", "Do not dwell in the past.", "Do not dream of the future.",
+          "My religion is love.", "Listen to your heart.", "If not now, when?",
+          "Get the inside right.", "Give your fullest attention.", "Gate, gate, paragate...",
+          "Let come what comes.", "Let go what goes.", "See what remains.",
+          "Each time for the first time.", "You need nothing more.", "I am detached.",
+          "There is only light.", "Your thoughts come and go.", "Express yourself as you are.",
+          "Breathe in deeply.", "Breathe out slowly.", "Feel what you feel now.",
+          "Put it all down.", "Let it all go.", "We're present now.",
+          "Be kind whenever possible.", "Nothing else matters now.", "Become still and alert."
+        ],
+        personalQuotes: [
+          "Sink is hungry...", "Sink believes in you~", "Sink had a nice nap.",
+          "Sink is proud of you!", "Sink loves a good sync.", "Sink feels cozy today.",
+          "Sink sends good vibes~", "Sink is happy here.", "Sink dreams of treats.",
+          "Sink is cheering you on!", "Sink's heart is full.", "Sink feels lucky today.",
+          "Sink knows you got this!", "Sink enjoys the typing.", "Sink is here for you.",
+          "Sink thinks you're great!", "Sink is contemplating...", "Sink appreciates you.",
+          "Sink is grateful~", "Sink wonders about meow.", "Sink needs more naps.",
+          "Sink likes this code.", "Sink is vibing~", "Sink says keep going!",
+          "Sink found a sunbeam."
+        ]
+      },
+      clippy: {
+        name: 'Clippy',
+        art: {
+          idle: \` __
+/  \\\\
+|  |
+@  @
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ ~z~\`,
+          syncing: \` __
+/  \\\\
+|  |
+◉  ◉
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ ~~~\`,
+          success: \` __
+/  \\\\
+|  |
+◠  ◠
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+*tip*\`,
+          error: \` __
+/  \\\\
+|  |
+×  ×
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ ?!?\`
+        },
+        talk: [
+          \` __
+/  \\\\
+|  |
+◔  ◔
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ ...\`,
+          \` __
+/  \\\\
+|  |
+◑  ◑
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ ...\`
+        ],
+        clickFace: \` __
+/  \\\\
+|  |
+⊙  ⊙
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ !!!\`,
+        eventArt: {
+          connecting: \` __
+/  \\\\
+|  |
+◉  ◉
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ ~~~\`,
+          connected: \` __
+/  \\\\
+|  |
+◠  ◠
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+*tip*\`,
+          disconnected: \` __
+/  \\\\
+|  |
+@  @
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ ~z~\`,
+          studioJoined: \` __
+/  \\\\
+|  |
+◉  ◉
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ !!!\`,
+          studioLeft: \` __
+/  \\\\
+|  |
+._  _.
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ ...\`,
+          studioLinked: \` __
+/  \\\\
+|  |
+◠  ◠
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+ yay!\`,
+          studioUnlinked: \` __
+/  \\\\
+|  |
+@  @
+|| ||
+|| ||
+|\\\\_/|
+\\\\___/
+  ok~\`
+        },
+        statusMessages: {
+          idle: ['~ Organizing...', '◦ Filing...', '✧ Standing by...', '~ Waiting...'],
+          syncing: ['✻ Working...', '◈ Syncing...', '⟳ Pushing...', '✦ Busy!'],
+          success: ['♡ Nailed it!', '✿ Perfect!', '★ Done!', '❋ Filed!'],
+          error: ['⚠ Oh no...', '✕ Uh oh...', '◇ Oops...'],
+          thinking: ['✻ Thinking...', '◦ Processing...', '✧ Hmm...'],
+          connecting: ['◈ Booting...', '✦ Starting...', '⟳ Connecting...'],
+        },
+        operationMessages: {
+          sync: ["Syncing your files!", "Pushing changes~", "Almost there!", "Uploading scripts...", "Just a moment!"],
+          extract: ["Extracting files!", "Grabbing instances~", "So many files!", "Downloading...", "Fetching data!"],
+          test: ["Running checks!", "Testing 1, 2, 3...", "Fingers crossed!", "Executing...", "Let's see!"],
+          success: ["All done! Great work!", "Filed successfully!", "Gold star!", "Nailed it!", "Success!"],
+          error: ["Oh no! Let me help!", "Something went wrong...", "Don't worry, I'm on it!", "Uh oh...", "Error detected!"],
+          serverStart: ["Server starting!", "Booting up...", "Initializing...", "Coming online!"],
+          serverConnected: ["Connected! Let's go!", "Ready to assist!", "All systems go!", "Online and ready~"],
+          serverStopped: ["Server stopped~", "Taking a break...", "Powering down...", "Going offline~"],
+          studioJoined: ["New connection!", "Hello Studio!", "Welcome!", "Studio just walked in!"],
+          studioLeft: ["Goodbye~", "Studio left...", "See you later!", "Studio has left the building."],
+          studioLinked: ["Linked up! Let's go!", "Connected!", "We're in business!", "Link established!"],
+          studioUnlinked: ["Unlinked~", "Disconnected...", "Link broken", "Connection lost..."]
+        },
+        greetings: [
+          "Hi! Clippy is here to help!", "Clippy reporting for duty!", "It looks like you need an assistant!",
+          "Clippy says hello!", "Welcome! Need any help?", "Good to see you!",
+          "Clippy is ready to assist!", "Hello, developer!", "Ready when you are!",
+          "Let's get productive!", "Clippy is happy to help!", "Welcome! Let's do this!",
+          "Hey! Let's get to work!", "Hi there! Ready to sync?", "Clippy at your service!"
+        ],
+        clickMessages: [
+          "Hey! I was filing!", "Clippy is surprised!", "Watch the wire!", "Easy on the clicks!",
+          "Clippy wobbles!", "*straightens up*", "I'm a paperclip!", "*bounces*",
+          "Careful there!", "That tickles!", "Need help?", "*springs back*",
+          "Still here!", "*wiggles*", "Click!", "*adjusts glasses*",
+          "Hello again!", "*spins*", "Boing!", "*waves*"
+        ],
+        quotes: [
+          "It looks like you're writing a script!", "A clean codebase is a happy codebase!",
+          "Remember to save early, save often!", "Have you tried turning it off and on again?",
+          "Pro tip: Ctrl+Z is your best friend.", "Did you know? Semicolons are optional in Luau!",
+          "A well-named variable is worth a thousand comments.", "Time for a code review?",
+          "Keep calm and keep coding!", "Don't forget to commit your work!",
+          "You're on a roll today!", "Remember: tabs vs spaces is a personal journey.",
+          "Your code is looking sharp today!", "The best code is no code at all.",
+          "Ship it!", "Have you considered a design pattern?",
+          "Refactor early, refactor often.", "Comments should explain why, not what.",
+          "Test your edge cases!", "Good code reads like prose.",
+          "Version control is your safety net.", "Small commits, clear messages.",
+          "Code is read more than it is written.", "Simplicity is the ultimate sophistication.",
+          "When in doubt, print it out.", "Rubber duck debugging works!",
+          "Take breaks. Your brain needs them.", "Documentation is a love letter to your future self.",
+          "Make it work, make it right, make it fast.", "Every bug is a lesson learned.",
+          "Stay curious, keep learning.", "There's always a simpler way.",
+          "The compiler is your friend.", "Don't repeat yourself!",
+          "Indent consistently.", "Read the error message carefully.",
+          "Coffee and code go hand in hand.", "Measure twice, code once.",
+          "Progress, not perfection.", "One function, one purpose.",
+          "Keep your dependencies tidy.", "Naming things is one of the hardest problems.",
+          "Let the tests guide you.", "You're doing great, keep it up!",
+          "Every expert was once a beginner.", "Automate the boring stuff.",
+          "Code review is a gift.", "Sleep on it. The answer will come.",
+          "Trust the process.", "Build for today, design for tomorrow."
+        ],
+        personalQuotes: [
+          "Clippy believes in your code~", "Clippy filed that under 'awesome'!",
+          "Clippy is organizing your paperwork...", "Clippy recommends a coffee break.",
+          "Clippy is proud of your progress!", "Clippy has been reviewing your files~",
+          "Clippy suggests: have you tried a for loop?", "Clippy is standing by for your next sync.",
+          "Clippy thinks your project structure is neat!", "Clippy noticed you haven't saved in a while...",
+          "Clippy appreciates good documentation.", "Clippy is impressed!",
+          "Clippy gives you a gold star.", "Clippy is watching and learning~",
+          "Clippy filed a bug report... just kidding!", "Clippy is optimizing...",
+          "Clippy says: ship it!", "Clippy found a syntax error... not really!",
+          "Clippy is vibing~", "Clippy is your #1 fan!",
+          "Clippy loves clean code.", "Clippy is here for you.",
+          "Clippy says keep going!", "Clippy found a coffee cup.",
+          "Clippy is feeling productive!"
+        ]
+      }
     };
 
-    // Greeting messages for first launch - high priority welcome
-    const CAT_GREETINGS = [
-      "Welcome back, friend!",
-      "Hello there! Ready to code?",
-      "Hi! Sink is here to help~",
-      "Welcome to RbxSync!",
-      "Hey! Let's build something!",
-      "Good to see you!",
-      "Sink reporting for duty!",
-      "Hello, developer!",
-      "Ready when you are~",
-      "Let's make something cool!",
-      "Sink is happy to see you!",
-      "Welcome! *purrs*",
-      "Hey friend! Let's go~",
-      "Hi hi! Ready to sync?",
-      "Sink says hello!"
-    ];
+    // Active mascot - will be set from VS Code setting
+    let activeMascotKey = 'sink';
+    let mascot = MASCOTS[activeMascotKey];
 
-    // Cat click reactions - fun cat things to say
-    const CAT_CLICK_MESSAGES = [
-      "Meow!",
-      "Mrrp?",
-      "Purrr~",
-      "*blinks slowly*",
-      "Nya~",
-      "*head bonk*",
-      "Pet me more!",
-      "*kneads paws*",
-      "Prrrrt!",
-      "*tail swish*",
-      "Feed me?",
-      "*chirp chirp*",
-      "So sleepy...",
-      "*stretches*",
-      "Mrow!",
-      "*flops over*",
-      "Treats?",
-      "*ear twitch*",
-      "Mew~",
-      "*purrs loudly*"
-    ];
+    // Helper to get all quotes (general + personal) for active mascot
+    function getAllQuotes() {
+      return [...mascot.quotes, ...mascot.personalQuotes];
+    }
 
     // Fun colors for cat clicks
     const CAT_CLICK_COLORS = [
@@ -1405,95 +1591,13 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       '#2dd4bf', // teal
     ];
 
-    // Zen wisdom quotes (short - max 2 lines)
-    const ZEN_QUOTES = [
-      "Just breathe.",
-      "Be here now.",
-      "There is only Now.",
-      "Breathe and let be.",
-      "Pay attention.",
-      "Attention!",
-      "What am I?",
-      "Om mani padme hum",
-      "When hungry, eat.",
-      "When tired, sleep.",
-      "You are the sky.",
-      "YOLO",
-      "Who is breathing?",
-      "Focus on your breath.",
-      "Let go of thinking.",
-      "Just be in this moment.",
-      "Do one thing at a time.",
-      "Do dishes, rake leaves.",
-      "Chop wood, carry water.",
-      "What you think, you become.",
-      "Nothing is permanent.",
-      "Seek the mind.",
-      "You are awareness.",
-      "There is only the Present.",
-      "Clean the floor with love.",
-      "Drink your tea slowly.",
-      "Attend the moment.",
-      "We have only now.",
-      "Do not dwell in the past.",
-      "Do not dream of the future.",
-      "My religion is love.",
-      "Listen to your heart.",
-      "If not now, when?",
-      "Get the inside right.",
-      "Give your fullest attention.",
-      "Gate, gate, paragate...",
-      "Let come what comes.",
-      "Let go what goes.",
-      "See what remains.",
-      "Each time for the first time.",
-      "You need nothing more.",
-      "I am detached.",
-      "There is only light.",
-      "Your thoughts come and go.",
-      "Express yourself as you are.",
-      "Breathe in deeply.",
-      "Breathe out slowly.",
-      "Feel what you feel now.",
-      "Put it all down.",
-      "Let it all go.",
-      "We're present now.",
-      "Be kind whenever possible.",
-      "Nothing else matters now.",
-      "Become still and alert."
-    ];
+    function updateCatStatus(mood) {
+      const statusEl = document.getElementById('zenCatStatus');
+      if (!statusEl) return;
+      const statuses = mascot.statusMessages[mood] || mascot.statusMessages.idle;
+      statusEl.textContent = statuses[Math.floor(Math.random() * statuses.length)];
+    }
 
-    // Sink's personal thoughts (short - max 2 lines)
-    const SINK_QUOTES = [
-      "Sink is hungry...",
-      "Sink believes in you~",
-      "Sink had a nice nap.",
-      "Sink is proud of you!",
-      "Sink loves a good sync.",
-      "Sink feels cozy today.",
-      "Sink sends good vibes~",
-      "Sink is happy here.",
-      "Sink dreams of treats.",
-      "Sink is cheering you on!",
-      "Sink's heart is full.",
-      "Sink feels lucky today.",
-      "Sink knows you got this!",
-      "Sink enjoys the typing.",
-      "Sink is here for you.",
-      "Sink thinks you're great!",
-      "Sink is contemplating...",
-      "Sink appreciates you.",
-      "Sink is grateful~",
-      "Sink wonders about meow.",
-      "Sink needs more naps.",
-      "Sink likes this code.",
-      "Sink is vibing~",
-      "Sink says keep going!",
-      "Sink found a sunbeam."
-    ];
-
-    // Combine all quotes
-    const ALL_QUOTES = [...ZEN_QUOTES, ...SINK_QUOTES];
 
     // Initialize zen cat quote feed
     let quoteIndex = 0;
@@ -1574,7 +1678,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       let talkFrame = 0;
       if (catEl && !isClickAnimating) {
         talkInterval = setInterval(() => {
-          catEl.textContent = CAT_TALK[talkFrame % 2];
+          catEl.textContent = mascot.talk[talkFrame % 2];
           talkFrame++;
         }, 150);
       }
@@ -1585,9 +1689,9 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       function typeChar() {
         if (i < text.length && currentTypewriterText === text) {
           displayText += text.charAt(i);
-          // Highlight "Sink" with cat's color, add cursor at end
+          // Highlight mascot name with cat's color, add cursor at end
           const catColor = getCatColor();
-          const highlighted = displayText.replace(/Sink/g, '<span class="sink-name" style="color:' + catColor + '">Sink</span>');
+          const highlighted = displayText.replace(new RegExp(mascot.name, 'g'), '<span class="sink-name" style="color:' + catColor + '">' + mascot.name + '</span>');
           element.innerHTML = highlighted + '<span class="typing-cursor">|</span>';
           i++;
           typewriterTimeout = setTimeout(typeChar, speed);
@@ -1596,7 +1700,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
           element.classList.remove('typing');
           // Remove cursor when done, show final text
           const catColor = getCatColor();
-          element.innerHTML = displayText.replace(/Sink/g, '<span class="sink-name" style="color:' + catColor + '">Sink</span>');
+          element.innerHTML = displayText.replace(new RegExp(mascot.name, 'g'), '<span class="sink-name" style="color:' + catColor + '">' + mascot.name + '</span>');
           // Stop talking animation and restore cat
           if (talkInterval) {
             clearInterval(talkInterval);
@@ -1612,7 +1716,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
 
     // Get random message for operation type
     function getOperationMessage(opType) {
-      const messages = CAT_MESSAGES[opType];
+      const messages = mascot.operationMessages[opType];
       if (!messages || messages.length === 0) return '';
       return messages[Math.floor(Math.random() * messages.length)];
     }
@@ -1642,12 +1746,12 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       if (!quoteEl) return;
 
       // Shuffle quotes for variety (mix zen + Sink quotes)
-      shuffledQuotes = [...ALL_QUOTES].sort(() => Math.random() - 0.5);
+      shuffledQuotes = [...getAllQuotes()].sort(() => Math.random() - 0.5);
 
       // Show greeting on first launch with high priority (8 seconds)
       // Also set greetingUntil to block server status messages during greeting
       if (isFirstLaunch) {
-        const greeting = CAT_GREETINGS[Math.floor(Math.random() * CAT_GREETINGS.length)];
+        const greeting = mascot.greetings[Math.floor(Math.random() * mascot.greetings.length)];
         greetingUntil = Date.now() + 8000;
         showPriorityMessage(greeting, quoteEl, 8000);
         isFirstLaunch = false;
@@ -1681,7 +1785,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       const catEl = document.getElementById('zenCatArt');
       if (!catEl) return;
 
-      catEl.textContent = CAT_ART[mood] || CAT_ART.idle;
+      catEl.textContent = mascot.art[mood] || mascot.art.idle;
       catEl.className = 'zen-cat ' + mood;
       updateCatStatus(mood);
     }
@@ -1699,11 +1803,8 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       // Pick random color
       const randomColor = CAT_CLICK_COLORS[Math.floor(Math.random() * CAT_CLICK_COLORS.length)];
 
-      // Show surprised face (4-line version)
-      catEl.textContent = \` /\\\\_/\\\\
-( O.O )
- />!<\\\\
- meow!\`;
+      // Show surprised face
+      catEl.textContent = mascot.clickFace;
       catEl.style.color = randomColor;
 
       // Add wiggle animation to container, color to speech bubble
@@ -1718,7 +1819,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
 
       // Show cat message with priority
       if (quoteEl) {
-        const catMsg = CAT_CLICK_MESSAGES[Math.floor(Math.random() * CAT_CLICK_MESSAGES.length)];
+        const catMsg = mascot.clickMessages[Math.floor(Math.random() * mascot.clickMessages.length)];
         showPriorityMessage(catMsg, quoteEl, 4000);
       }
 
@@ -1765,10 +1866,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
         if (connStatus === 'connecting' && lastConnectionStatus !== 'connecting') {
           // Server starting - show alert cat with animation
           if (catEl) {
-            catEl.textContent = \` /\\\\_/\\\\
-( o.o )
- />~<\\\\
-  ~~~\`;
+            catEl.textContent = mascot.eventArt.connecting;
             catEl.style.color = '#facc15';
           }
           updateCatStatus('connecting');
@@ -1785,10 +1883,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
         } else if (connStatus === 'connected' && lastConnectionStatus !== 'connected') {
           // Server connected - show happy cat
           if (catEl) {
-            catEl.textContent = \` /\\\\_/\\\\
-( ^.^ )
- />v<\\\\
-*purr*\`;
+            catEl.textContent = mascot.eventArt.connected;
             catEl.style.color = '#4ade80';
           }
           updateCatStatus('success');
@@ -1817,10 +1912,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
         } else if (connStatus === 'disconnected' && lastConnectionStatus && lastConnectionStatus !== 'disconnected') {
           // Server stopped - show sleepy cat
           if (catEl) {
-            catEl.textContent = \` /\\\\_/\\\\
-( -.- )
- />♡<\\\\
-  ~z~\`;
+            catEl.textContent = mascot.eventArt.disconnected;
             catEl.style.color = '#a78bfa';
           }
           if (container) {
@@ -1858,10 +1950,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
         if (currentPlaceCount > lastPlaceCount && lastPlaceCount > 0) {
           // New studio joined
           if (catEl) {
-            catEl.textContent = \` /\\\\_/\\\\
-( o.o )
- />~<\\\\
-  !!!\`;
+            catEl.textContent = mascot.eventArt.studioJoined;
             catEl.style.color = '#60a5fa';
           }
           if (quoteEl) {
@@ -1882,10 +1971,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
         } else if (currentPlaceCount < lastPlaceCount) {
           // Studio left
           if (catEl) {
-            catEl.textContent = \` /\\\\_/\\\\
-( ;.; )
- />~<\\\\
-  ...\`;
+            catEl.textContent = mascot.eventArt.studioLeft;
             catEl.style.color = '#a78bfa';
           }
           if (quoteEl) {
@@ -1922,10 +2008,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       for (const id of currentLinkedIds) {
         if (!lastLinkedPlaceIds.has(id) && lastLinkedPlaceIds.size > 0 || (lastLinkedPlaceIds.size === 0 && currentLinkedIds.size > 0 && lastPlaceCount > 0)) {
           if (catEl) {
-            catEl.textContent = \` /\\\\_/\\\\
-( ^.^ )
- />v<\\\\
- yay!\`;
+            catEl.textContent = mascot.eventArt.studioLinked;
             catEl.style.color = '#4ade80';
           }
           if (quoteEl) {
@@ -1950,10 +2033,7 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       for (const id of lastLinkedPlaceIds) {
         if (!currentLinkedIds.has(id)) {
           if (catEl) {
-            catEl.textContent = \` /\\\\_/\\\\
-( -.- )
- />~<\\\\
-  ok~\`;
+            catEl.textContent = mascot.eventArt.studioUnlinked;
             catEl.style.color = '#facc15';
           }
           if (quoteEl) {

--- a/rbxsync-vscode/src/views/sidebarWebview.ts
+++ b/rbxsync-vscode/src/views/sidebarWebview.ts
@@ -31,6 +31,8 @@ interface SidebarState {
   rbxjsonHidden: boolean;
   // Cat panel visibility
   catVisible: boolean;
+  // Active mascot selection
+  activeMascot: 'sink' | 'clippy';
 }
 
 /**
@@ -74,7 +76,8 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
     catMood: 'idle',
     catOperationType: null,
     rbxjsonHidden: true,
-    catVisible: true
+    catVisible: true,
+    activeMascot: vscode.workspace.getConfiguration('rbxsync').get<string>('mascot', 'sink') as 'sink' | 'clippy'
   };
 
   constructor(extensionUri: vscode.Uri, version?: string) {
@@ -151,6 +154,13 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
           break;
       }
     });
+
+    vscode.workspace.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration('rbxsync.mascot')) {
+        this.state.activeMascot = vscode.workspace.getConfiguration('rbxsync').get<string>('mascot', 'sink') as 'sink' | 'clippy';
+        this._updateWebview();
+      }
+    });
   }
 
   public setConnectionStatus(
@@ -200,6 +210,15 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
     this.state.catVisible = !this.state.catVisible;
     this._updateWebview();
     return this.state.catVisible;
+  }
+
+  public cycleMascot(): void {
+    const mascots: Array<'sink' | 'clippy'> = ['sink', 'clippy'];
+    const currentIndex = mascots.indexOf(this.state.activeMascot);
+    this.state.activeMascot = mascots[(currentIndex + 1) % mascots.length];
+    // Persist to VS Code setting
+    vscode.workspace.getConfiguration('rbxsync').update('mascot', this.state.activeMascot, vscode.ConfigurationTarget.Global);
+    this._updateWebview();
   }
 
   public setUpdateAvailable(version: string | null): void {

--- a/rbxsync-vscode/src/views/sidebarWebview.ts
+++ b/rbxsync-vscode/src/views/sidebarWebview.ts
@@ -158,12 +158,16 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
       }
     });
 
-    vscode.workspace.onDidChangeConfiguration(e => {
+    const configDisposable = vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration('rbxsync.mascot')) {
-        this.state.activeMascot = vscode.workspace.getConfiguration('rbxsync').get<string>('mascot', 'sink') as 'sink' | 'clippy';
-        this._updateWebview();
+        const newMascot = vscode.workspace.getConfiguration('rbxsync').get<string>('mascot', 'sink') as 'sink' | 'clippy';
+        if (newMascot !== this.state.activeMascot) {
+          this.state.activeMascot = newMascot;
+          this._updateWebview();
+        }
       }
     });
+    webviewView.onDidDispose(() => configDisposable.dispose());
   }
 
   public setConnectionStatus(
@@ -1865,8 +1869,19 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
     initZenCat();
 
     // Add click handler to cat
-    document.getElementById('zenCat')?.addEventListener('click', onCatClick);
+    let clickTimeout = null;
+    document.getElementById('zenCat')?.addEventListener('click', () => {
+      if (clickTimeout) return; // second click of a dblclick
+      clickTimeout = setTimeout(() => {
+        clickTimeout = null;
+        onCatClick();
+      }, 250);
+    });
     document.getElementById('zenCat')?.addEventListener('dblclick', (e) => {
+      if (clickTimeout) {
+        clearTimeout(clickTimeout);
+        clickTimeout = null;
+      }
       e.preventDefault();
       vscode.postMessage({ command: 'cycleMascot' });
     });

--- a/rbxsync-vscode/src/views/sidebarWebview.ts
+++ b/rbxsync-vscode/src/views/sidebarWebview.ts
@@ -152,6 +152,9 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
           this.state.updateAvailable = null;
           this._updateWebview();
           break;
+        case 'cycleMascot':
+          this.cycleMascot();
+          break;
       }
     });
 
@@ -1863,6 +1866,10 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
 
     // Add click handler to cat
     document.getElementById('zenCat')?.addEventListener('click', onCatClick);
+    document.getElementById('zenCat')?.addEventListener('dblclick', (e) => {
+      e.preventDefault();
+      vscode.postMessage({ command: 'cycleMascot' });
+    });
 
     window.addEventListener('message', e => {
       if (e.data.type === 'stateUpdate') {
@@ -1872,6 +1879,23 @@ export class SidebarWebviewProvider implements vscode.WebviewViewProvider {
     });
 
     function render(s) {
+      // Switch active mascot if setting changed
+      const newMascotKey = s.activeMascot || 'sink';
+      if (newMascotKey !== activeMascotKey) {
+        activeMascotKey = newMascotKey;
+        mascot = MASCOTS[activeMascotKey];
+        // Re-shuffle quotes for new mascot
+        shuffledQuotes = [...getAllQuotes()].sort(() => Math.random() - 0.5);
+        quoteIndex = 0;
+        // Show greeting from new mascot
+        const quoteEl2 = document.getElementById('zenQuote');
+        if (quoteEl2) {
+          const greeting = mascot.greetings[Math.floor(Math.random() * mascot.greetings.length)];
+          showPriorityMessage(greeting, quoteEl2, 5000);
+        }
+        // Update the displayed art immediately
+        updateCatMood(s.catMood || 'idle');
+      }
       // Update zen cat mood and message
       const catMood = s.catMood || 'idle';
       const opType = s.catOperationType;


### PR DESCRIPTION
## Summary

- Adds Microsoft's Clippy as an optional mascot alongside Sink the zen cat
- New `rbxsync.mascot` VS Code setting (enum: `sink` | `clippy`, default: `sink`)
- Double-click the mascot in the sidebar to cycle between mascots
- Classic Clippy personality with office/productivity-themed quotes and messages
- All dialog dynamically references the active mascot's name

## Details

Refactors hardcoded Sink mascot data into a `MASCOTS` data model with per-mascot ASCII art (4 moods), status messages, operation messages, greetings, click reactions, and quotes. Clippy gets his own paperclip ASCII art with `@`/`◉`/`◠`/`×` eyes per mood state.

Mascot choice persists to VS Code global settings and syncs both ways (sidebar ↔ Settings UI).

## Test plan

- [ ] Verify Sink mascot still works as before (default behavior unchanged)
- [ ] Switch to Clippy via Settings > RbxSync > Mascot and verify ASCII art changes
- [ ] Double-click the mascot to cycle — verify it switches and shows a greeting
- [ ] Single-click still triggers wiggle animation (no double-fire on dblclick)
- [ ] Verify Clippy's messages reference "Clippy" not "Sink"
- [ ] Verify setting persists across VS Code restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)