### PR TITLE
fix(cli): restore wait_for_port_release, unbreak workspace build

### DIFF
--- a/rbxsync-cli/src/main.rs
+++ b/rbxsync-cli/src/main.rs
@@ -1253,6 +1253,20 @@ fn is_port_available(port: u16) -> bool {
     std::net::TcpListener::bind(format!("127.0.0.1:{}", port)).is_ok()
 }
 
+/// Poll until the port is released or the timeout elapses. Returns true if released.
+async fn wait_for_port_release(port: u16, timeout_ms: u64) -> bool {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    loop {
+        if is_port_available(port) {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
 /// Stop server on a specific port
 async fn stop_server_on_port(port: u16) -> Result<()> {
     // First, try to find any rbxsync server processes by port


### PR DESCRIPTION
## Problem
`master` does not compile. `cmd_stop` in `rbxsync-cli/src/main.rs` calls `wait_for_port_release` at three sites (lines 1284/1300/1316), but the function is not defined anywhere in the crate — it was dropped during the context-file refactor while its callers were left in place. `cargo build --workspace` fails with three `E0425: cannot find function` errors.

## Fix
Reimplement `wait_for_port_release(port, timeout_ms)` next to the existing `is_port_available`, as a poll over `is_port_available` with a deadline (100ms tick). Smallest change that restores the intended behavior of the stop command's graceful → SIGTERM → SIGKILL escalation.

## Verification
- `cargo check --workspace` ✅ green
- `cargo build --workspace` ✅ green

🤖 Generated with [Claude Code](https://claude.com/claude-code)