### PR TITLE
feat(server): finalize Studio extraction into datamodel.rbxjson

### DIFF
--- a/rbxsync-server/src/lib.rs
+++ b/rbxsync-server/src/lib.rs
@@ -2057,13 +2057,15 @@ async fn handle_extract_finalize(
     // Maximum concurrent file writes to prevent overwhelming the filesystem
     const MAX_CONCURRENT_WRITES: usize = 64;
 
-    // Decide directories, script adoptions, and .rbxjson writes for the extracted tree
+    // Decide directories and script adoptions for the extracted tree. Non-script
+    // instance state is written as the single datamodel.rbxjson context document
+    // below, not as per-instance files, so json_ops is unused here.
     let rbxsync_core::extract_tree::WritePlan {
         dirs: directories_needed,
         script_ops: script_write_ops,
-        json_ops: json_write_ops,
         adopted,
         service_folders,
+        ..
     } = rbxsync_core::extract_tree::plan_instance_writes(&src_dir, &all_instances, &tree_mapping);
 
     // Batch create all directories (run in blocking task to not block async runtime)
@@ -2094,29 +2096,41 @@ async fn handle_extract_finalize(
         .await;
     let scripts_written = script_results.iter().filter(|&&ok| ok).count();
 
-    // Write JSON files in parallel
-    let json_count = json_write_ops.len();
-    let json_results: Vec<bool> = stream::iter(json_write_ops)
-        .map(|op| async move {
-            tokio::fs::write(&op.path, &op.content).await.is_ok()
-        })
-        .buffer_unordered(MAX_CONCURRENT_WRITES)
-        .collect()
-        .await;
-    let files_written = json_results.iter().filter(|&&ok| ok).count();
+    // Write the entire non-script instance tree as the single datamodel.rbxjson
+    // context document (atomic tmp+rename, stamps snapshot freshness).
+    let total_instances = all_instances.len();
+    let ctx_project_dir = req.project_dir.clone();
+    let context_written = tokio::task::spawn_blocking(move || {
+        rbxsync_core::context_tree::write_context_file(
+            std::path::Path::new(&ctx_project_dir),
+            &all_instances,
+            &tree_mapping,
+        )
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(format!("context write task panicked: {}", e))));
+
+    let context_ok = match &context_written {
+        Ok(_) => true,
+        Err(e) => {
+            tracing::error!("Failed to write datamodel.rbxjson: {}", e);
+            false
+        }
+    };
+    let files_written = if context_ok { 1 } else { 0 };
 
     tracing::info!(
-        "Wrote {} scripts and {} json files in {:?} ({} concurrent writes)",
-        scripts_written, files_written, write_start.elapsed(), MAX_CONCURRENT_WRITES
+        "Wrote {} scripts and the context document in {:?} ({} concurrent writes)",
+        scripts_written, write_start.elapsed(), MAX_CONCURRENT_WRITES
     );
 
     // Log if there were any failures
     let script_failures = script_count - scripts_written;
-    let json_failures = json_count - files_written;
-    if script_failures > 0 || json_failures > 0 {
+    if script_failures > 0 || !context_ok {
         tracing::warn!(
-            "Write failures: {} scripts, {} json files",
-            script_failures, json_failures
+            "Write failures: {} scripts, context document {}",
+            script_failures,
+            if context_ok { "ok" } else { "FAILED" }
         );
     }
 
@@ -2166,8 +2180,8 @@ async fn handle_extract_finalize(
     }
 
     tracing::info!(
-        "Finalize complete: {} .rbxjson files, {} .luau scripts, {} services{}",
-        files_written,
+        "Finalize complete: datamodel.rbxjson ({} instances), {} .luau scripts, {} services{}",
+        total_instances,
         scripts_written,
         service_folders.len(),
         if packages_preserved { ", packages preserved" } else { "" }
@@ -2227,7 +2241,7 @@ async fn handle_extract_finalize(
             "success": true,
             "filesWritten": files_written,
             "scriptsWritten": scripts_written,
-            "totalInstances": all_instances.len(),
+            "totalInstances": total_instances,
             "adopted": adopted
         })),
     )

--- a/rbxsync-server/tests/extract_tests.rs
+++ b/rbxsync-server/tests/extract_tests.rs
@@ -71,7 +71,7 @@ fn adopted_of(body: &serde_json::Value) -> Vec<String> {
 }
 
 #[tokio::test]
-async fn test_bootstrap_writes_scripts_and_sidecars() {
+async fn test_bootstrap_writes_scripts_and_context_file() {
     let server = create_test_server();
     let dir = tempfile::tempdir().unwrap();
     let body = run_extraction(&server, &dir, json!([
@@ -82,9 +82,18 @@ async fn test_bootstrap_writes_scripts_and_sidecars() {
     assert_eq!(body["success"], true);
     let main = dir.path().join("src/ServerScriptService/Main.server.luau");
     assert_eq!(std::fs::read_to_string(&main).unwrap(), "print('main')");
-    let sidecar = std::fs::read_to_string(dir.path().join("src/ServerScriptService/Main.rbxjson")).unwrap();
-    assert!(!sidecar.contains("\"Source\""));
-    assert!(dir.path().join("src/Workspace/Part.rbxjson").exists());
+    // Non-script state lives in the single datamodel.rbxjson context document at
+    // the project root, not in per-instance sidecars. Scripts carry a sourcePath,
+    // never their Source.
+    let context = std::fs::read_to_string(dir.path().join("datamodel.rbxjson")).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&context).unwrap();
+    assert_eq!(doc["className"], "DataModel");
+    assert!(context.contains("\"sourcePath\""));
+    assert!(context.contains("ServerScriptService/Main.server.luau"));
+    assert!(!context.contains("\"Source\""), "script Source must be stripped from the context doc");
+    assert!(context.contains("\"Part\""), "non-script instances live in the context doc");
+    assert!(!dir.path().join("src/ServerScriptService/Main.rbxjson").exists(), "no per-instance sidecars");
+    assert!(!dir.path().join("src/Workspace/Part.rbxjson").exists(), "no per-instance sidecars");
     assert_eq!(adopted_of(&body), vec!["ServerScriptService/Main.server.luau"]);
     assert_eq!(body["scriptsWritten"], 1);
 
@@ -110,8 +119,8 @@ async fn test_reextract_preserves_modified_script() {
     assert_eq!(std::fs::read_to_string(&main).unwrap(), "-- local edit");
     assert!(adopted_of(&body).is_empty());
     assert_eq!(body["scriptsWritten"], 0);
-    // Sidecar still refreshed
-    assert!(dir.path().join("src/ServerScriptService/Main.rbxjson").exists());
+    // Context document refreshed each extraction
+    assert!(dir.path().join("datamodel.rbxjson").exists());
 }
 
 #[tokio::test]
@@ -172,7 +181,7 @@ async fn test_orphan_rbxjson_cleaned_scripts_survive() {
 
     assert!(!src.join("Workspace/Old.rbxjson").exists(), "orphaned instance file must be cleared");
     assert!(src.join("ReplicatedStorage/Keep.luau").exists(), "orphaned script must survive");
-    assert!(src.join("Workspace/Part.rbxjson").exists());
+    assert!(dir.path().join("datamodel.rbxjson").exists(), "extracted tree written to the context doc");
 }
 
 #[tokio::test]
@@ -259,7 +268,7 @@ async fn test_start_without_project_dir_does_not_mark_prepared() {
 
     // Finalize must have run its own prepare: stale instance file cleared
     assert!(!src.join("Workspace/Stale.rbxjson").exists());
-    assert!(src.join("Workspace/Part.rbxjson").exists());
+    assert!(dir.path().join("datamodel.rbxjson").exists());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why
The refactor to the single `datamodel.rbxjson` context file was only half-wired. Three write paths existed and disagreed:

| Path | Format before this PR |
|------|------|
| CLI offline extract (`extract --from-file`) | new — `datamodel.rbxjson` ✅ |
| Live Studio deltas (edits during a session) | new — patches `datamodel.rbxjson` ✅ |
| **Studio "extract game" (`handle_extract_finalize`)** | **old — per-instance `.rbxjson` + `_meta.rbxjson`, never wrote `datamodel.rbxjson`** ❌ |

The load-bearing extraction path (what the Studio plugin actually drives) still emitted the retired multi-file format. This PR converts it, so all three paths agree.

## What
- `handle_extract_finalize` now writes the whole non-script instance tree as the single `datamodel.rbxjson` context document via `context_tree::write_context_file`, run on a `spawn_blocking` task so the large-game write doesn't stall the async runtime.
- Per-instance `.rbxjson` / `_meta.rbxjson` writes (`json_ops`) are no longer emitted.
- **Preserved** the bounded-concurrency parallel *script* writes (the RBXSYNC-26 large-game perf fix) and the adopt-once script semantics, dir/service-folder creation, package preservation, terrain handling, and backup/prepare flow — all unchanged.
- Updated `extract_tests.rs`: the 5 assertions that expected per-instance sidecars now assert the context document (root `datamodel.rbxjson`, `sourcePath` present, `Source` stripped, no sidecars).

## Verification
- `cargo build -p rbxsync-server` ✅
- `cargo clippy -p rbxsync-server --tests` ✅ clean
- `cargo test -p rbxsync-server -p rbxsync-core` ✅ **151 passed, 0 failed** (incl. extract 9/9, sync-relay 15/15, harness 19/19)

Part of the v1.4 "finish the refactor" work. Held for review — do not merge until the docs/site PRs land and you've had a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)