### PR TITLE
chore: refresh CLAUDE.md, add CHANGELOG, bump to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to RbxSync are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.4.0] - unreleased
+
+This release replaces the per-instance multi-file rbxjson format with a single
+hidden, read-only `datamodel.rbxjson` context document at the project root, and
+keeps scripts as standalone `.luau` files on disk.
+
+### Added
+
+- Single `datamodel.rbxjson` context document: the flat instance array is assembled
+  into a nested context tree and written once per extract, with scripts carrying a
+  `sourcePath` pointer instead of inline source.
+- CLI `extract --from-file` builds the baseline snapshot from a saved place file and
+  writes one `datamodel.rbxjson`, adopting existing scripts.
+- Live Studio deltas (create/modify/delete/rename) are patched into the context tree
+  and relayed into `datamodel.rbxjson` via a debounced flush, with re-buffering when
+  a flush fails.
+- rbx-dom stack upgraded to parse modern place files.
+
+### Changed
+
+- Server extract path migrated to the context-file model: instance state now lives
+  only in `datamodel.rbxjson`, and read/sync handlers resolve against the context
+  document.
+- VS Code treats `datamodel.rbxjson` as a hidden, read-only context file and includes
+  script-less services in the generated `default.project.json`.
+- Core plans script writes as standalone files and preserves duplicate-named siblings
+  in the context document.
+
+### Removed
+
+- Retired the per-instance `.rbxjson` + `_meta.rbxjson` multi-file format, including
+  the non-script `.rbxjson` readers and the file-watcher push path on the server.
+- Retired the standalone rbxjson language server.
+- Removed the per-instance VS Code decorations, tree view, and `openMetadata` command.
+- Removed the flat-format schema pipeline and the rbxjson schema update CI workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,35 +9,25 @@ RbxSync is a bidirectional sync tool between Roblox Studio and local filesystem.
 - External editor support (VS Code)
 - AI-assisted development via MCP
 
-**Current Version:** v1.3.0
-**Status:** Active development
+**Current Version:** v1.4.0
+**Status:** Preparing v1.4.0 release
 
 ---
 
 ## Critical Context
 
-### Current Priority: BUG BASH
+### Current State
 
-**Recently fixed:**
-- ~~RBXSYNC-24~~ - Data loss with ScriptSync
-- ~~RBXSYNC-25~~ - Script timeout on large games
-- ~~RBXSYNC-26~~ - Large game extraction slow
-- ~~RBXSYNC-27~~ - Clear src folder before extraction
-- ~~RBXSYNC-28~~ - Delete orphans UI in VS Code
-- ~~RBXSYNC-30~~ - Extraction fails with excluded services
-- ~~RBXSYNC-17~~ - Windows path corruption
-- ~~RBXSYNC-33~~ - Zero-config mode
-- ~~RBXSYNC-34~~ - Echo prevention flag
-- ~~RBXSYNC-35~~ - 50ms deduplication window
-- ~~RBXSYNC-36~~ - GetDebugId for instance IDs
-- ~~RBXSYNC-38~~ - Union deletion during extract
+v1.4.0 replaces the per-instance `.rbxjson` + `_meta.rbxjson` sidecar format with a
+single hidden, read-only `datamodel.rbxjson` context document at the project root.
+Scripts are written as standalone `.luau` files under `src/`; the context document
+holds the rest of the instance tree by nesting and points each script at its
+`sourcePath` instead of carrying source. The standalone rbxjson language server and
+the per-instance VS Code decorations/tree view were retired as part of the same
+refactor.
 
-**Active bugs:**
-| Issue | Priority | Problem |
-|-------|----------|---------|
-| RBXSYNC-5 | - | Instance renames not handled |
-| RBXSYNC-18 | - | Multiple terminal windows in VS Code |
-| RBXSYNC-19 | - | Luau LSP can't find project.json |
+No formal issue tracker is wired up in this repo right now; track work in
+`TASKS.md` / commit history and open a PR per change (see Git Workflow below).
 
 ---
 
@@ -45,14 +35,20 @@ RbxSync is a bidirectional sync tool between Roblox Studio and local filesystem.
 
 ```
 rbxsync/
-├── rbxsync-core/     # Core serialization, DOM handling (Rust)
-├── rbxsync-server/   # HTTP server, sync logic (Rust)
-├── rbxsync-cli/      # CLI interface (Rust)
-├── rbxsync-mcp/      # MCP server for AI tools (Rust)
-├── rbxsync-vscode/   # VS Code extension (TypeScript)
-├── plugin/           # Roblox Studio plugin (Luau)
-└── .claude/          # AI agent configs and hooks
+├── datamodel.rbxjson   # Hidden, read-only whole-datamodel context document (generated)
+├── src/                # Standalone script sources (.luau), one file per script instance
+├── rbxsync-core/       # Core serialization, context-tree assembly, DOM handling (Rust)
+├── rbxsync-server/     # HTTP server, sync logic, live delta flush (Rust, axum)
+├── rbxsync-cli/        # CLI interface (Rust, clap)
+├── rbxsync-mcp/        # MCP server for AI tools (Rust, rmcp)
+├── rbxsync-vscode/     # VS Code extension (TypeScript)
+├── plugin/             # Roblox Studio plugin (Luau)
+└── .claude/            # AI agent configs and hooks
 ```
+
+`datamodel.rbxjson` and the `src/` script tree are produced by extraction; the
+context document is regenerated on extract and folded with live Studio deltas via a
+debounced flush, so treat it as generated output rather than hand-edited source.
 
 ---
 
@@ -130,9 +126,10 @@ If you are a teammate working on a task:
 
 | Component | Entry Point | Purpose |
 |-----------|-------------|---------|
-| Server | `rbxsync-server/src/server.rs` | HTTP server, sync logic |
+| Server | `rbxsync-server/src/lib.rs` | HTTP server, sync logic |
 | Core | `rbxsync-core/src/lib.rs` | DOM, serialization |
-| MCP | `rbxsync-mcp/src/lib.rs` | AI tool handlers |
+| Core (context tree) | `rbxsync-core/src/context_tree.rs` | `datamodel.rbxjson` assembly + delta patching |
+| MCP | `rbxsync-mcp/src/main.rs` | MCP server entry, tool registrations |
 | Plugin | `plugin/src/Sync.luau` | Studio sync logic |
 | VS Code | `rbxsync-vscode/src/extension.ts` | Extension entry |
 
@@ -140,15 +137,15 @@ If you are a teammate working on a task:
 
 ## MCP Tools Available
 
-When running with `rbxsync serve`, these MCP tools are available:
+When running with `rbxsync serve`, 46 MCP tools are registered (see
+`rbxsync-mcp/src/main.rs`). By area:
 
-- `extract_game` - Extract game from Studio to files
-- `sync_to_studio` - Push local changes to Studio
-- `run_test` - Start playtest
-- `run_code` - Execute Luau in Studio
-- `bot_observe` - Get game state during playtest
-- `bot_move` - Move character
-- `bot_action` - Perform actions (equip, interact, etc.)
+- **Extract / sync:** `extract_game`, `sync_to_studio`, `diff`, `set_active_place`, `insert_model`, `git_status`, `git_commit`
+- **Scripting:** `run_code`, `get_script_source`, `set_script_source`, `edit_script_lines`
+- **Instances:** `read_properties`, `explore_hierarchy`, `find_instances`, `create_instance`, `delete_instance`, `duplicate_instance`, `get_selection`, `get_class_info`, `set_property`, `mass_set_property`, `search_by_property`
+- **Tags / attributes:** `get_tags`, `add_tag`, `remove_tag`, `get_tagged`, `get_attributes`, `set_attribute`, `delete_attribute`
+- **Bot / playtest:** `run_test`, `stop_test`, `start_playtest`, `stop_playtest`, `playtest_status`, `bot_observe`, `bot_move`, `bot_action`, `bot_command`, `bot_query_server`, `bot_wait_for`, `verify`
+- **Harness:** `harness_init`, `harness_session_start`, `harness_session_end`, `harness_feature_update`, `harness_status`
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 license = "LicenseRef-Proprietary"
 authors = ["RbxSync Team"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbxsync",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "build": "cd docs && npm install && npm run build",

--- a/rbxsync-vscode/package.json
+++ b/rbxsync-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rbxsync",
   "displayName": "RbxSync",
   "description": "Two-way sync between Roblox Studio and VS Code. One-click extraction, real-time bidirectional sync, console streaming, and MCP integration for AI workflows.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "SEE LICENSE IN LICENSE.txt",
   "publisher": "rbxsync",
   "icon": "media/icons/rbxsync.png",


### PR DESCRIPTION
Repo-hygiene housekeeping for the v1.4.0 context-file refactor. Docs + version strings only — no Rust logic touched.

## CLAUDE.md — corrected stale facts against source
- **Version/status:** `v1.3.0` / "Active development" → `v1.4.0` / "Preparing v1.4.0 release".
- **Bug bash section:** removed the pre-refactor "Recently fixed" list and the "Active bugs" table (RBXSYNC-5/18/19); replaced with a short honest current-state note (no invented bug list).
- **Key Files paths — both were wrong:**
  - `rbxsync-server/src/server.rs` → `rbxsync-server/src/lib.rs` (server.rs does not exist)
  - `rbxsync-mcp/src/lib.rs` → `rbxsync-mcp/src/main.rs` (mcp lib.rs does not exist)
  - added `rbxsync-core/src/context_tree.rs` for the context-tree assembly
  - every path verified to exist.
- **MCP tools: 7 → 46.** The old inline list named 7 tools; the real server registers **46** `#[tool]` functions in `rbxsync-mcp/src/main.rs`. Replaced with all 46 names grouped by area (extract/sync, scripting, instances, tags/attributes, bot/playtest, harness).
- **Project Structure:** now reflects the single hidden read-only `datamodel.rbxjson` context document + standalone `.luau` scripts under `src/`.
- **AGENTS rules section:** left untouched.

## CHANGELOG.md — new
Keep a Changelog format with a `## [1.4.0] - unreleased` section (Added/Changed/Removed) summarizing the move to the single `datamodel.rbxjson` context file, retirement of the multi-file rbxjson format + language server + per-instance decorations, and the server extract-path migration. Grounded in `git log`.

## Version bump 1.3.0 → 1.4.0
Workspace `Cargo.toml` (`[workspace.package]`), root `package.json`, `rbxsync-vscode/package.json`. Grep confirmed no other package/version declarations needed bumping (remaining `1.3.0` hits are docs/history/example fixtures, left alone).

## Build note
`cargo build --workspace` currently fails on a **pre-existing** error unrelated to this PR: `wait_for_port_release` not found in `rbxsync-cli/src/main.rs` (owned by the in-flight `fix/rbxsync-cli-wait-for-port-release` branch). Verified the same error is present on the base commit with these changes stashed; every crate except the CLI bin compiles, so the version-string edits parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)