### PR TITLE
feat(mcp): reinstate connection_status and console_history tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,10 +137,10 @@ If you are a teammate working on a task:
 
 ## MCP Tools Available
 
-When running with `rbxsync serve`, 46 MCP tools are registered (see
+When running with `rbxsync serve`, 47 MCP tools are registered (see
 `rbxsync-mcp/src/main.rs`). By area:
 
-- **Extract / sync:** `extract_game`, `sync_to_studio`, `diff`, `set_active_place`, `insert_model`, `git_status`, `git_commit`
+- **Extract / sync:** `extract_game`, `sync_to_studio`, `diff`, `connection_status`, `set_active_place`, `insert_model`, `git_status`, `git_commit`
 - **Scripting:** `run_code`, `get_script_source`, `set_script_source`, `edit_script_lines`
 - **Instances:** `read_properties`, `explore_hierarchy`, `find_instances`, `create_instance`, `delete_instance`, `duplicate_instance`, `get_selection`, `get_class_info`, `set_property`, `mass_set_property`, `search_by_property`
 - **Tags / attributes:** `get_tags`, `add_tag`, `remove_tag`, `get_tagged`, `get_attributes`, `set_attribute`, `delete_attribute`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,10 +137,10 @@ If you are a teammate working on a task:
 
 ## MCP Tools Available
 
-When running with `rbxsync serve`, 47 MCP tools are registered (see
+When running with `rbxsync serve`, 48 MCP tools are registered (see
 `rbxsync-mcp/src/main.rs`). By area:
 
-- **Extract / sync:** `extract_game`, `sync_to_studio`, `diff`, `connection_status`, `set_active_place`, `insert_model`, `git_status`, `git_commit`
+- **Extract / sync:** `extract_game`, `sync_to_studio`, `diff`, `connection_status`, `console_history`, `set_active_place`, `insert_model`, `git_status`, `git_commit`
 - **Scripting:** `run_code`, `get_script_source`, `set_script_source`, `edit_script_lines`
 - **Instances:** `read_properties`, `explore_hierarchy`, `find_instances`, `create_instance`, `delete_instance`, `duplicate_instance`, `get_selection`, `get_class_info`, `set_property`, `mass_set_property`, `search_by_property`
 - **Tags / attributes:** `get_tags`, `add_tag`, `remove_tag`, `get_tagged`, `get_attributes`, `set_attribute`, `delete_attribute`

--- a/rbxsync-mcp/src/luau_helpers.rs
+++ b/rbxsync-mcp/src/luau_helpers.rs
@@ -254,8 +254,8 @@ mod tests {
             "42"
         );
         assert_eq!(
-            json_value_to_luau(&serde_json::json!(3.14)),
-            "3.14"
+            json_value_to_luau(&serde_json::json!(1.5)),
+            "1.5"
         );
     }
 

--- a/rbxsync-mcp/src/main.rs
+++ b/rbxsync-mcp/src/main.rs
@@ -74,6 +74,17 @@ pub struct DiffParams {
     pub project_dir: String,
 }
 
+/// Parameters for console_history tool
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConsoleHistoryParams {
+    /// Maximum number of messages to return (default: 50, max: 1000)
+    #[schemars(description = "Max messages to return (default: 50, max: 1000)")]
+    pub limit: Option<u32>,
+    /// Filter by message type: "error", "warn", "info"
+    #[schemars(description = "Filter by type: 'error', 'warn', 'info' (omit for all)")]
+    pub message_type: Option<String>,
+}
+
 /// Parameters for git_commit tool
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GitCommitParams {
@@ -1073,6 +1084,62 @@ impl RbxSyncServer {
             lines.push("Status: not ready - open Roblox Studio with the RbxSync plugin installed".to_string());
         } else {
             lines.push("Status: ready for sync/extract".to_string());
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(lines.join("\n"))]))
+    }
+
+    /// Get recent console output from Roblox Studio.
+    /// Returns log messages with timestamps and types (error/warn/info),
+    /// optionally filtered by type. Messages are captured while the Studio
+    /// plugin is pushing console output to the server.
+    #[tool(description = "Get recent console output from Roblox Studio - log messages with timestamps and types (error/warn/info), optionally filtered by type.")]
+    async fn console_history(
+        &self,
+        Parameters(params): Parameters<ConsoleHistoryParams>,
+    ) -> Result<CallToolResult, McpError> {
+        if let Some(err) = self.require_connection().await? {
+            return Ok(err);
+        }
+
+        let limit = params.limit.unwrap_or(50).min(1000);
+        let result = self.client
+            .get_console_history(limit)
+            .await
+            .map_err(|e| mcp_error(e.to_string()))?;
+
+        let mut messages = result.messages;
+        if let Some(ref filter_type) = params.message_type {
+            messages.retain(|m| m.message_type == *filter_type);
+        }
+
+        if messages.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "Console: no messages (total in buffer: {})",
+                result.total
+            ))]));
+        }
+
+        let mut lines = vec![format!(
+            "Console ({} messages, showing {}):",
+            result.total,
+            messages.len()
+        )];
+        lines.push(String::new());
+
+        for msg in &messages {
+            let type_label = match msg.message_type.as_str() {
+                "error" => "[ERROR]",
+                "warn" => "[WARN] ",
+                "info" => "[INFO] ",
+                _ => "[LOG]  ",
+            };
+            let source = msg.source.as_deref().unwrap_or("");
+            if source.is_empty() {
+                lines.push(format!("{} {} {}", type_label, msg.timestamp, msg.message));
+            } else {
+                lines.push(format!("{} {} {} {}", type_label, msg.timestamp, source, msg.message));
+            }
         }
 
         Ok(CallToolResult::success(vec![Content::text(lines.join("\n"))]))

--- a/rbxsync-mcp/src/main.rs
+++ b/rbxsync-mcp/src/main.rs
@@ -1016,6 +1016,68 @@ impl RbxSyncServer {
         Ok(CallToolResult::success(vec![Content::text(lines.join("\n"))]))
     }
 
+    /// Report server status and connected clients.
+    /// Returns server health and version, connected Roblox Studio places,
+    /// and registered VS Code workspaces. Call before extract, sync, or diff
+    /// to verify the system is ready.
+    #[tool(description = "Report server status and connected clients - server health, Studio places, and VS Code workspaces. Call before extract/sync/diff to verify the system is ready.")]
+    async fn connection_status(&self) -> Result<CallToolResult, McpError> {
+        let health = match self.client.get_health().await {
+            Ok(h) if h.status == "ok" => h,
+            _ => {
+                return Ok(CallToolResult::success(vec![Content::text(
+                    "Server: not running. Start it with 'rbxsync serve'.",
+                )]));
+            }
+        };
+
+        let version = health.version.as_deref().unwrap_or("unknown");
+        let mut lines = vec![format!("Server: running (v{})", version)];
+
+        let places = self.client.get_places().await.unwrap_or_default();
+        lines.push(String::new());
+        if places.is_empty() {
+            lines.push("Studio: no places connected".to_string());
+        } else {
+            lines.push(format!(
+                "Studio: {} place{} connected",
+                places.len(),
+                if places.len() == 1 { "" } else { "s" }
+            ));
+            for place in &places {
+                let name = if place.place_name.is_empty() { "Unnamed" } else { &place.place_name };
+                lines.push(format!(
+                    "  • \"{}\" (Place ID: {}) → {}",
+                    name, place.place_id, place.project_dir
+                ));
+            }
+        }
+
+        let workspaces = self.client.get_workspaces().await.unwrap_or_default();
+        lines.push(String::new());
+        if workspaces.is_empty() {
+            lines.push("VS Code: no workspaces registered".to_string());
+        } else {
+            lines.push(format!(
+                "VS Code: {} workspace{}",
+                workspaces.len(),
+                if workspaces.len() == 1 { "" } else { "s" }
+            ));
+            for ws in &workspaces {
+                lines.push(format!("  • {}", ws));
+            }
+        }
+
+        lines.push(String::new());
+        if places.is_empty() {
+            lines.push("Status: not ready - open Roblox Studio with the RbxSync plugin installed".to_string());
+        } else {
+            lines.push("Status: ready for sync/extract".to_string());
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(lines.join("\n"))]))
+    }
+
     /// Get the git status of a project directory.
     #[tool(description = "Get git status of the project")]
     async fn git_status(

--- a/rbxsync-mcp/src/tools/mod.rs
+++ b/rbxsync-mcp/src/tools/mod.rs
@@ -375,6 +375,31 @@ pub struct DiffResponse {
     pub unchanged: usize,
 }
 
+/// A connected Studio place from the /rbxsync/places endpoint
+#[derive(Debug, Deserialize)]
+pub struct PlaceEntry {
+    #[serde(default)]
+    pub place_id: u64,
+    #[serde(default)]
+    pub place_name: String,
+    #[serde(default)]
+    pub project_dir: String,
+}
+
+/// Response from the /rbxsync/places endpoint
+#[derive(Debug, Deserialize)]
+pub struct PlacesResponse {
+    #[serde(default)]
+    pub places: Vec<PlaceEntry>,
+}
+
+/// Response from the /rbxsync/workspaces endpoint
+#[derive(Debug, Deserialize)]
+pub struct WorkspacesResponse {
+    #[serde(default)]
+    pub workspaces: Vec<String>,
+}
+
 impl RbxSyncClient {
     pub fn new(port: u16) -> Self {
         Self {
@@ -859,6 +884,34 @@ impl RbxSyncClient {
             .await?;
 
         send_and_parse(response, "get_diff").await
+    }
+
+    /// Get the server version and liveness from the health endpoint
+    pub async fn get_health(&self) -> anyhow::Result<HealthResponse> {
+        let response = self.client.get(format!("{}/health", self.base_url)).send().await?;
+        send_and_parse(response, "get_health").await
+    }
+
+    /// Get the connected Studio places
+    pub async fn get_places(&self) -> anyhow::Result<Vec<PlaceEntry>> {
+        let response = self
+            .client
+            .get(format!("{}/rbxsync/places", self.base_url))
+            .send()
+            .await?;
+        let resp: PlacesResponse = send_and_parse(response, "get_places").await?;
+        Ok(resp.places)
+    }
+
+    /// Get the registered VS Code workspaces
+    pub async fn get_workspaces(&self) -> anyhow::Result<Vec<String>> {
+        let response = self
+            .client
+            .get(format!("{}/rbxsync/workspaces", self.base_url))
+            .send()
+            .await?;
+        let resp: WorkspacesResponse = send_and_parse(response, "get_workspaces").await?;
+        Ok(resp.workspaces)
     }
 
     // ========================================================================

--- a/rbxsync-mcp/src/tools/mod.rs
+++ b/rbxsync-mcp/src/tools/mod.rs
@@ -375,6 +375,28 @@ pub struct DiffResponse {
     pub unchanged: usize,
 }
 
+/// A console message from Studio's log buffer
+#[derive(Debug, Deserialize)]
+pub struct ConsoleHistoryEntry {
+    #[serde(default)]
+    pub timestamp: String,
+    #[serde(default)]
+    pub message_type: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+/// Response from the /console/history endpoint
+#[derive(Debug, Deserialize)]
+pub struct ConsoleHistoryResponse {
+    #[serde(default)]
+    pub messages: Vec<ConsoleHistoryEntry>,
+    #[serde(default)]
+    pub total: usize,
+}
+
 /// A connected Studio place from the /rbxsync/places endpoint
 #[derive(Debug, Deserialize)]
 pub struct PlaceEntry {
@@ -884,6 +906,17 @@ impl RbxSyncClient {
             .await?;
 
         send_and_parse(response, "get_diff").await
+    }
+
+    /// Get recent console messages from the server's log buffer
+    pub async fn get_console_history(&self, limit: u32) -> anyhow::Result<ConsoleHistoryResponse> {
+        let response = self
+            .client
+            .get(format!("{}/console/history?limit={}", self.base_url, limit))
+            .send()
+            .await?;
+
+        send_and_parse(response, "get_console_history").await
     }
 
     /// Get the server version and liveness from the health endpoint

--- a/rbxsync-server/tests/routing_tests.rs
+++ b/rbxsync-server/tests/routing_tests.rs
@@ -100,3 +100,37 @@ async fn test_operation_status_matches_across_path_styles() {
         "operation keyed by one path style must be visible via the other: {body:#?}"
     );
 }
+
+#[tokio::test]
+async fn test_health_reports_version() {
+    let server = create_test_server();
+
+    let health = server.get("/health").await;
+    health.assert_status_ok();
+    let body: serde_json::Value = health.json();
+    assert_eq!(body["status"], "ok");
+    assert!(
+        body["version"].as_str().is_some_and(|v| !v.is_empty()),
+        "health must report a non-empty version: {body:#?}"
+    );
+}
+
+#[tokio::test]
+async fn test_registered_workspace_is_listed() {
+    let server = create_test_server();
+
+    let register = server
+        .post("/rbxsync/register-vscode")
+        .json(&json!({ "workspace_dir": "C:/Users/rt/ws" }))
+        .await;
+    register.assert_status_ok();
+
+    let workspaces = server.get("/rbxsync/workspaces").await;
+    workspaces.assert_status_ok();
+    let body: serde_json::Value = workspaces.json();
+    let dirs = body["workspaces"].as_array().unwrap();
+    assert!(
+        dirs.iter().any(|d| d == "c:/Users/rt/ws"),
+        "registered workspace must appear in the list: {body:#?}"
+    );
+}

--- a/rbxsync-server/tests/routing_tests.rs
+++ b/rbxsync-server/tests/routing_tests.rs
@@ -134,3 +134,30 @@ async fn test_registered_workspace_is_listed() {
         "registered workspace must appear in the list: {body:#?}"
     );
 }
+
+#[tokio::test]
+async fn test_pushed_console_messages_appear_in_history() {
+    let server = create_test_server();
+
+    let push = server
+        .post("/console/push")
+        .json(&json!({
+            "messages": [
+                { "timestamp": "0.0", "message_type": "info", "message": "starting", "source": "sync" },
+                { "timestamp": "0.1", "message_type": "error", "message": "boom", "source": null }
+            ]
+        }))
+        .await;
+    push.assert_status_ok();
+
+    let history = server.get("/console/history").add_query_param("limit", 10).await;
+    history.assert_status_ok();
+    let body: serde_json::Value = history.json();
+    assert_eq!(body["total"], 2);
+    let messages = body["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0]["message_type"], "info");
+    assert_eq!(messages[0]["timestamp"], "0.0");
+    assert_eq!(messages[0]["message"], "starting");
+    assert_eq!(messages[1]["message_type"], "error");
+}


### PR DESCRIPTION
## Summary

Reinstates two MCP tools that were written in March but lost during the
`datamodel.rbxjson` refactor. Re-implemented against current `master`
(v1.4.0) following the current tool patterns, not applied from the old
stash diff.

Tool count goes 46 → 48.

## Ported

### `connection_status` (no params)
Reports server health + version, connected Studio places, and registered
VS Code workspaces so an agent can verify the system is ready before
`extract`/`sync`/`diff`. All server-side data already exists — the tool
reuses the existing `/health`, `/rbxsync/places`, and
`/rbxsync/workspaces` endpoints (in-memory `place_registry` /
`vscode_workspaces` state). No server changes.

### `console_history` (optional `limit`, `message_type`)
Returns recent Studio console output from the server's ring buffer with
an optional limit and type filter for AI debugging loops. Backed by the
existing `/console/history` endpoint and `console_buffer`. No server
changes.

Note on usefulness: the console buffer is populated via `/console/push`,
which the Studio plugin drives on the console-streaming path. Outside
that path the buffer can legitimately be empty — the tool reports the
buffer total so that's visible rather than surprising.

## Skipped

### `sourcemap` — intentionally not ported
The old stash added a `/sourcemap` server endpoint that walked `src/` to
emit a standalone `sourcemap.json`, duplicating the CLI's
`build_sourcemap_node`. Under the current model the Luau LSP surface is
`default.project.json`, synthesized by the VS Code extension
(`rbxsync-vscode/src/lsp/projectJson.ts`) from `datamodel.rbxjson` + the
`src/` tree on extract. The stash's `include_non_scripts` path also keys
off retired per-instance `.rbxjson` files, which extraction no longer
produces. Porting it would duplicate existing CLI logic to serve a
surface already covered by project.json synthesis, with no remaining MCP
consumer — so it's left out, matching the task's stated default.

### `diff` — already on master, untouched.

## Tests

Added three server contract tests in `rbxsync-server/tests/routing_tests.rs`
(the crate the endpoints live in; the MCP crate has no integration-test
harness and its reqwest client can't reach `axum_test`'s mock transport):
- `/health` reports a non-empty version (`connection_status`)
- a registered VS Code workspace appears in `/rbxsync/workspaces` (`connection_status`)
- pushed console messages round-trip through `/console/history` with the
  expected `message_type`/`timestamp`/`message` shape and `total` (`console_history`)

## Incidental fix
`cargo clippy --workspace --tests` was already failing on `master` on a
pre-existing `clippy::approx_constant` (a `3.14` literal in
`test_number_to_luau`). Changed it to `1.5` so the required clippy gate
is green; the test only needs a non-integer float.

## Verification
- `cargo build --workspace` — clean (pre-existing dead-code warnings only)
- `cargo test --workspace` — all suites pass, 0 failures (routing_tests 6/6)
- `cargo clippy --workspace --tests` — no errors (pre-existing dead-code warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
